### PR TITLE
ovirt-img: Implement Backend.ReadAt

### DIFF
--- a/go/backend.go
+++ b/go/backend.go
@@ -8,8 +8,11 @@
 
 package imageio
 
+import "io"
+
 // Backend exposes a disk image for transferring image data.
 type Backend interface {
+	io.ReaderAt
 
 	// Size return the size of the underlying disk image.
 	Size() (uint64, error)

--- a/ovirt-img/nbd/nbd_test.go
+++ b/ovirt-img/nbd/nbd_test.go
@@ -9,7 +9,10 @@
 package nbd
 
 import (
+	"bytes"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -32,6 +35,54 @@ func TestNbdSize(t *testing.T) {
 	} else if size != imageSize {
 		t.Errorf("backend.Size() = %v, expected %v", size, imageSize)
 	}
+}
+
+func TestNbdReadAt(t *testing.T) {
+	// TODO: Requires empty 6g image exposed via qemu-nbd
+	b, err := Connect("nbd+unix://?socket=/tmp/nbd.sock")
+	if err != nil {
+		t.Fatalf("Connect failed: %s", err)
+	}
+	defer b.Close()
+
+	// Image is empty, so we expect to get zeroes.
+	// TODO: Fill image with more intresting data.
+	expected := make([]byte, 4096)
+
+	// Read first block.
+	if err := checkReadAt(b, 0, expected); err != nil {
+		t.Error(err)
+	}
+
+	// Read block in the middle.
+	if err := checkReadAt(b, int64(3*units.GiB), expected); err != nil {
+		t.Error(err)
+	}
+
+	// Read last block.
+	if err := checkReadAt(b, int64(6*units.GiB-4096), expected); err != nil {
+		t.Error(err)
+	}
+
+	// Read block 2048 bytes after end of image.
+	if err := checkReadAt(b, int64(6*units.GiB-2048), expected[:2048]); err != nil {
+		t.Error(err)
+	}
+}
+
+func checkReadAt(b imageio.Backend, off int64, expected []byte) error {
+	buf := bytes.Repeat([]byte("x"), 4096)
+
+	n, err := b.ReadAt(buf, off)
+	if n != len(expected) {
+		return fmt.Errorf("Unexpected length: %s", err)
+	}
+
+	if !bytes.Equal(buf[:n], expected) {
+		return fmt.Errorf("Unexpected data: %v", hex.Dump(buf[:n]))
+	}
+
+	return nil
 }
 
 func TestNbdExtents(t *testing.T) {


### PR DESCRIPTION
Backend.ReadAt() implements the io.ReaderAt interface. This is similar
to pread(2)[1] and our python client library ImageioClient.read()[2]

The change exposes some issues in the current code:

- All sizes should use int64 instead of uint64. This is what standard
  library is using (e.g. io.Reader). We use uint64 because of libnbd.

- The nbd and http tests are mostly identical. Move the common parts of
  the tests to the imageio module. This will also be useful for 3rd
  party projects that want to create new backends.

[1] https://man7.org/linux/man-pages/man2/pread.2.html
[2] https://github.com/oVirt/ovirt-imageio/blob/master/ovirt_imageio/client/_api.py#L377