### PR TITLE
http: Configurable inactivity timeout

### DIFF
--- a/data/README
+++ b/data/README
@@ -47,6 +47,17 @@
 # The default value:
 #   max_connections = 8
 
+# Number of seconds before unauthorized connections are
+# disconnected.
+# The default value:
+#   auth_timeout = 15
+
+# Number of seconds before inactive connections are disconnected.
+# Clients with special needs can request a larger timeout when
+# creating an image transfer.
+# The default value:
+#   inactivity_timeout = 60
+
 [tls]
 # Enable TLS. Note that without TLS transfer tickets and image data are
 # transferred in clear text. If TLS is enabled, paths to related files

--- a/examples/nbd.json
+++ b/examples/nbd.json
@@ -4,6 +4,7 @@
     "size": 6442450944,
     "url": "nbd:unix:/tmp/nbd.sock",
     "timeout": 3000,
+    "inactivity_timeout": 300,
     "sparse": true,
     "ops": ["read", "write"]
 }

--- a/ovirt_imageio/_internal/backends/__init__.py
+++ b/ovirt_imageio/_internal/backends/__init__.py
@@ -98,6 +98,9 @@ def get(req, ticket, config):
             ctx.close()
             raise
 
+        # Authorized connections get a longer timeout from the ticket.
+        req.set_connection_timeout(ticket.inactivity_timeout)
+
         # Register a closer removing the context when the connection is closed.
         req.context[ticket.uuid] = Closer(
             partial(ticket.remove_context, req.connection_id))

--- a/ovirt_imageio/_internal/config.py
+++ b/ovirt_imageio/_internal/config.py
@@ -20,6 +20,15 @@ class daemon:
     # decrease throughput.
     max_connections = 8
 
+    # Number of seconds before unauthorized connections are
+    # disconnected.
+    auth_timeout = 15
+
+    # Number of seconds before inactive connections are disconnected.
+    # Clients with special needs can request a larger timeout when
+    # creating an image transfer.
+    inactivity_timeout = 60
+
     # Daemon run directory. Runtime stuff like socket or profile information
     # will be stored in this directory.
     # This is configurable only for development purposes and is not expected to

--- a/ovirt_imageio/_internal/http.py
+++ b/ovirt_imageio/_internal/http.py
@@ -169,10 +169,11 @@ class Connection(http.server.BaseHTTPRequestHandler):
     # to support long URIs, so we use small value.
     max_request_line = 4096
 
-    # Number of second to wait for recv() or send(). When the timeout expires
-    # we close the connection. This is important when working with clients that
-    # keep the connection open after upload or download (e.g browsers).
-    timeout = 60
+    # Number of second to wait for recv() or send() on unauthorized
+    # connections.  When the timeout expires we close the connection.
+    # Authorized connections get a larger timeout using the ticket
+    # inactivity timeout.
+    timeout = 15
 
     # For generating connection ids. Start from 1 to match the connection
     # thread name.
@@ -270,6 +271,10 @@ class Connection(http.server.BaseHTTPRequestHandler):
         Used in Server header.
         """
         return "imageio/" + version.string
+
+    def set_timeout(self, timeout):
+        log.debug("Setting connection timeout to %s seconds", timeout)
+        self.connection.settimeout(timeout)
 
 
 class Request:
@@ -452,6 +457,9 @@ class Request:
         Return True if the underlying socket was disconnected.
         """
         return self._con.connection_error() in _DISCONNECTED
+
+    def set_connection_timeout(self, timeout):
+        self._con.set_timeout(timeout)
 
 
 class Response:

--- a/test/admin_test.py
+++ b/test/admin_test.py
@@ -89,6 +89,7 @@ def test_get_ticket(srv, fake_time):
             "size": ticket["size"],
             "sparse": ticket["sparse"],
             "dirty": ticket["dirty"],
+            "inactivity_timeout": ticket["inactivity_timeout"],
             "timeout": ticket["timeout"],
             "url": ticket["url"],
             "uuid": ticket["uuid"],

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -39,7 +39,7 @@ def random_tcp_port():
 
 def create_ticket(uuid=None, ops=None, timeout=300, size=2**64,
                   url="file:///tmp/foo.img", transfer_id=None, filename=None,
-                  sparse=None, dirty=None):
+                  sparse=None, dirty=None, inactivity_timeout=120):
     d = {
         "uuid": uuid or str(uuid4()),
         "timeout": timeout,
@@ -55,6 +55,8 @@ def create_ticket(uuid=None, ops=None, timeout=300, size=2**64,
         d["sparse"] = sparse
     if dirty is not None:
         d["dirty"] = dirty
+    if inactivity_timeout is not None:
+        d["inactivity_timeout"] = inactivity_timeout
     return d
 
 


### PR DESCRIPTION
We used 60 seconds timeout for disconnecting inactive clients. This is
too long to protect from bad clients leaving open connections, and too
short for applications that need long timeout[1].

Change the default timeout to 15 seconds, configurable via
daemon:auth_timeout. This timeout is used for new unauthorized
connections. If a connection does not authorize within this timeout, it
is disconnected.

When a connection is authorized during the first request, the connection
timeout is increased to ticket.inactivity_timeout. The default value is
60 seconds, configurable via daemon:inactivity_timeout.

Application with special needs can request a larger timeout when
creating an image transfer. Engine need to include the transfer
inactivity timeout in the ticket.

[1] https://bugzilla.redhat.com/2032324

Fixes #14.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>