### PR TITLE
backends/ndb: Avoid double close logs

### DIFF
--- a/ovirt_imageio/_internal/backends/nbd.py
+++ b/ovirt_imageio/_internal/backends/nbd.py
@@ -146,8 +146,10 @@ class Backend:
         return self._position
 
     def close(self):
-        log.info("Close backend address=%r", self._client.address)
-        self._client.close()
+        if self._client is not _CLOSED:
+            log.info("Close backend address=%r", self._client.address)
+            self._client.close()
+            self._client = _CLOSED
 
     def __enter__(self):
         return self
@@ -219,3 +221,11 @@ class Backend:
 
     def size(self):
         return self._client.export_size
+
+
+class Closed:
+    def __getattr__(self, name):
+        raise IOError("Backend was closed")
+
+
+_CLOSED = Closed()


### PR DESCRIPTION
If the backend of an idle connection is closed when ticket is canceled,
the backend is closed again when the idle connection is closed. Closing
backend multiple times is designed to be safe, but we should really log
only once, when actually closing the nbd client.

The same behavior is already implemented in the file backend.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>