### PR TITLE
docker: Disable quay.io caching

### DIFF
--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -1,7 +1,8 @@
 FROM quay.io/centos/centos:stream8
 
 # Runtime packages.
-RUN dnf install -y dnf-plugins-core \
+RUN echo v1 \
+    && dnf install -y dnf-plugins-core \
     && dnf copr enable -y \
         ovirt/ovirt-master-snapshot \
         centos-stream-8 \

--- a/docker/Dockerfile.centos-9
+++ b/docker/Dockerfile.centos-9
@@ -1,7 +1,8 @@
 FROM quay.io/centos/centos:stream9
 
 # Runtime packages.
-RUN dnf install -y dnf-plugins-core \
+RUN echo v1 \
+    && dnf install -y dnf-plugins-core \
     && dnf copr enable -y ovirt/ovirt-master-snapshot \
     && dnf install -y ovirt-release-master \
     && dnf install -y \

--- a/docker/Dockerfile.fedora-34
+++ b/docker/Dockerfile.fedora-34
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:34
 
 # Runtime packages.
-RUN dnf install -y dnf-plugins-core \
+RUN echo v1 \
+    && dnf install -y dnf-plugins-core \
     && dnf copr -y enable @virtmaint-sig/virt-preview \
     && dnf install -y \
         createrepo_c \

--- a/docker/Dockerfile.fedora-35
+++ b/docker/Dockerfile.fedora-35
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:35
 
 # Runtime packages.
-RUN dnf install -y dnf-plugins-core \
+RUN echo v1 \
+    && dnf install -y dnf-plugins-core \
     && dnf copr -y enable @virtmaint-sig/virt-preview \
     && dnf install -y \
         createrepo_c \


### PR DESCRIPTION
quay.io never updates our containers unless we change the list of
packages, so we don't get updates when new packages are released, and we
fail to detect regressions in packages we depend on.

Add a version to the RUN line. The version should be modified each time
we want to rebuild the containers.

Adding a workflow the build the container is probably better, but
require more work.