### PR TITLE
CODEOWNERS: Add oVirt documentation team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,8 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for all files:
-*  @nirs @vjuranek
+*               @nirs @vjuranek
 
 # Documentation owners
-# /docs/  @myname
+docs/           @nirs @vjuranek @oVirt/ovirt-documentation
+README.md       @nirs @vjuranek @oVirt/ovirt-documentation


### PR DESCRIPTION
Add @oVirt/ovirt-documentation to watch the docs/ and README.md.