### PR TITLE
qemu_nbd: Disable allocation depth for raw format

### DIFF
--- a/ovirt_imageio/_internal/nbd.py
+++ b/ovirt_imageio/_internal/nbd.py
@@ -653,11 +653,13 @@ class Client:
             if ctx_name == dirty_bitmap:
                 self.dirty_bitmap = dirty_bitmap
 
-        # Warn if we failed to activate some meta context. This may affect
-        # performance or reduce funcionaliity.
+        # Log if some meta context is not available. This may affect
+        # performance or reduce funcionaliity, but is expected when using old
+        # qemu-nbd (e.g. 4.2.0) or when using raw volume that does not provide
+        # interesting allocation depth, and triggers a bug in qemu 6.2.0.
         for ctx_name in queries:
             if ctx_name not in self._meta_context:
-                log.warning("Failed to activate %s", ctx_name)
+                log.info("Meta context %s is not available", ctx_name)
 
     def _format_meta_context_data(self, *queries):
         """

--- a/ovirt_imageio/_internal/qemu_nbd.py
+++ b/ovirt_imageio/_internal/qemu_nbd.py
@@ -123,7 +123,13 @@ class Server:
         # support RHEL users that have qemu-nbd 4.2.0. Add the option only on
         # qemu-nbd >= 5.2.0, and disable backing_chain=False otherwise.
         if version() >= (5, 2, 0):
-            cmd.append("--allocation-depth")
+            # qemu-nbd 6.2.0 introduced a regression, returning wrong
+            # base:allocation results on the second call when accessing raw
+            # image.  Since raw image always reports single allocation depth
+            # extent, we can safely disable it for raw images.
+            # https://lists.nongnu.org/archive/html/qemu-block/2022-01/msg00292.html
+            if self.fmt != "raw":
+                cmd.append("--allocation-depth")
         elif self.fmt == "qcow2" and not self.backing_chain:
             raise RuntimeError(
                 "backing_chain=False requires qemu-nbd >= 5.2.0")

--- a/test/nbd_test.py
+++ b/test/nbd_test.py
@@ -113,7 +113,7 @@ def test_handshake(tmpdir, export, fmt):
             assert c.maximum_block_size == 32 * 1024**2
             # Both available in in current qemu-nbd (>= 5.2.0).
             assert c.has_base_allocation
-            assert c.has_allocation_depth
+            assert c.has_allocation_depth == (fmt != "raw")
 
 
 def test_raw_read(tmpdir):

--- a/test/qemu_nbd_test.py
+++ b/test/qemu_nbd_test.py
@@ -318,10 +318,14 @@ def test_detect_zeroes_enabled(tmpdir, fmt, detect_zeroes):
         c.flush()
         extents = c.extents(0, size)
 
-    assert extents == {
-        "base:allocation": [nbd.Extent(length=1048576, flags=3)],
-        "qemu:allocation-depth": [nbd.Extent(length=1048576, flags=0)],
-    }
+    assert extents["base:allocation"] == [
+        nbd.Extent(length=1048576, flags=3),
+    ]
+
+    if fmt != "raw":
+        assert extents["qemu:allocation-depth"] == [
+            nbd.Extent(length=1048576, flags=0),
+        ]
 
 
 @pytest.mark.parametrize("fmt", ["raw", "qcow2"])
@@ -338,7 +342,11 @@ def test_detect_zeroes_disabled(tmpdir, fmt, detect_zeroes):
         c.flush()
         extents = c.extents(0, size)
 
-    assert extents == {
-        "base:allocation": [nbd.Extent(length=1048576, flags=0)],
-        "qemu:allocation-depth": [nbd.Extent(length=1048576, flags=0)],
-    }
+    assert extents["base:allocation"] == [
+        nbd.Extent(length=1048576, flags=0),
+    ]
+
+    if fmt != "raw":
+        assert extents["qemu:allocation-depth"] == [
+            nbd.Extent(length=1048576, flags=0),
+        ]


### PR DESCRIPTION
qemu-nbd 6.2.0 introduced a bug[1] when accessing raw image extents. The
first call works correctly, but the next calls the entire image is
reported as data.

Example failure:

>>> pprint(c.extents(0, c.export_size))
DEBUG:nbd:Sending NBD_CMD_BLOCK_STATUS handle=0 offset=0 length=1073741824 flags=0
DEBUG:nbd:Extent length=1073741824 flags=3 context=0
DEBUG:nbd:Extent length=1073741824 flags=1 context=1
{'base:allocation': [Extent(length=1073741824, flags=3)],
 'qemu:allocation-depth': [Extent(length=1073741824, flags=0)]}

We got the flags = 3  (NBD_STATE_HOLE | NBD_STATE_ZERO)

>>> pprint(c.extents(0, c.export_size))
DEBUG:nbd:Sending NBD_CMD_BLOCK_STATUS handle=1 offset=0 length=1073741824 flags=0
DEBUG:nbd:Extent length=1073741824 flags=0 context=0
DEBUG:nbd:Extent length=1073741824 flags=1 context=1
{'base:allocation': [Extent(length=1073741824, flags=0)],
 'qemu:allocation-depth': [Extent(length=1073741824, flags=0)]}

We got the flags = 0  (data)

Turns out that the bug is triggered by getting allocation depth; this is
handled incorrectly and corrupt the block status cache.

Since allocation depth is not useful for raw image (always reporting
depth=1) we can avoid this issue by disabling --allocation-depth option
in qemu_nbd helper for raw format.

Same change is needed in vdsm, qemu-nbd for real image transfers.

[1] https://bugzilla.redhat.com/2041480

Signed-off-by: Nir Soffer <nsoffer@redhat.com>