### PR TITLE
io: Fix backend closing in executor.

### DIFF
--- a/ovirt_imageio/_internal/backends/__init__.py
+++ b/ovirt_imageio/_internal/backends/__init__.py
@@ -48,6 +48,27 @@ class Closer:
         self.close = func
 
 
+class Wrapper:
+    """
+    Use to lend a backend without closing the wrapped backend.
+    """
+
+    def __init__(self, backend):
+        self._backend = backend
+
+    def close(self):
+        self._backend = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, t, v, tb):
+        self.close()
+
+    def __getattr__(self, name):
+        return getattr(self._backend, name)
+
+
 def supports(name):
     return name in _modules
 

--- a/ovirt_imageio/_internal/io.py
+++ b/ovirt_imageio/_internal/io.py
@@ -17,6 +17,7 @@ from contextlib import closing
 from functools import partial
 
 from . import util
+from . backends import Wrapper
 
 # Limit maximum zero and copy size to spread the workload better to multiple
 # workers and ensure frequent progress updates when handling large extents.
@@ -45,9 +46,10 @@ def copy(src, dst, dirty=False, max_workers=MAX_WORKERS,
         # iterate over image extents. We need to clone src backend max_workers
         # times, and dst backend max_workers - 1) times.
 
-        # The first worker clones src and use dst itself.
+        # The first worker clones src and use a wrapped dst.
         executor.add_worker(
-            partial(Handler, src.clone, lambda: dst, buffer_size, progress))
+            partial(Handler, src.clone, lambda: Wrapper(dst), buffer_size,
+                    progress))
 
         # The rest of the workers clone both src and dst.
         for _ in range(max_workers - 1):

--- a/ovirt_imageio/_internal/nbd.py
+++ b/ovirt_imageio/_internal/nbd.py
@@ -653,11 +653,13 @@ class Client:
             if ctx_name == dirty_bitmap:
                 self.dirty_bitmap = dirty_bitmap
 
-        # Warn if we failed to activate some meta context. This may affect
-        # performance or reduce funcionaliity.
+        # Log if some meta context is not available. This may affect
+        # performance or reduce funcionaliity, but is expected when using old
+        # qemu-nbd (e.g. 4.2.0) or when using raw volume that does not provide
+        # interesting allocation depth, and triggers a bug in qemu 6.2.0.
         for ctx_name in queries:
             if ctx_name not in self._meta_context:
-                log.warning("Failed to activate %s", ctx_name)
+                log.info("Meta context %s is not available", ctx_name)
 
     def _format_meta_context_data(self, *queries):
         """

--- a/ovirt_imageio/_internal/qemu_nbd.py
+++ b/ovirt_imageio/_internal/qemu_nbd.py
@@ -123,7 +123,13 @@ class Server:
         # support RHEL users that have qemu-nbd 4.2.0. Add the option only on
         # qemu-nbd >= 5.2.0, and disable backing_chain=False otherwise.
         if version() >= (5, 2, 0):
-            cmd.append("--allocation-depth")
+            # qemu-nbd 6.2.0 introduced a regression, returning wrong
+            # base:allocation results on the second call when accessing raw
+            # image.  Since raw image always reports single allocation depth
+            # extent, we can safely disable it for raw images.
+            # https://lists.nongnu.org/archive/html/qemu-block/2022-01/msg00292.html
+            if self.fmt != "raw":
+                cmd.append("--allocation-depth")
         elif self.fmt == "qcow2" and not self.backing_chain:
             raise RuntimeError(
                 "backing_chain=False requires qemu-nbd >= 5.2.0")

--- a/test/nbd_test.py
+++ b/test/nbd_test.py
@@ -113,7 +113,7 @@ def test_handshake(tmpdir, export, fmt):
             assert c.maximum_block_size == 32 * 1024**2
             # Both available in in current qemu-nbd (>= 5.2.0).
             assert c.has_base_allocation
-            assert c.has_allocation_depth
+            assert c.has_allocation_depth == (fmt != "raw")
 
 
 def test_raw_read(tmpdir):

--- a/test/qemu_nbd_test.py
+++ b/test/qemu_nbd_test.py
@@ -318,10 +318,14 @@ def test_detect_zeroes_enabled(tmpdir, fmt, detect_zeroes):
         c.flush()
         extents = c.extents(0, size)
 
-    assert extents == {
-        "base:allocation": [nbd.Extent(length=1048576, flags=3)],
-        "qemu:allocation-depth": [nbd.Extent(length=1048576, flags=0)],
-    }
+    assert extents["base:allocation"] == [
+        nbd.Extent(length=1048576, flags=3),
+    ]
+
+    if fmt != "raw":
+        assert extents["qemu:allocation-depth"] == [
+            nbd.Extent(length=1048576, flags=0),
+        ]
 
 
 @pytest.mark.parametrize("fmt", ["raw", "qcow2"])
@@ -338,7 +342,11 @@ def test_detect_zeroes_disabled(tmpdir, fmt, detect_zeroes):
         c.flush()
         extents = c.extents(0, size)
 
-    assert extents == {
-        "base:allocation": [nbd.Extent(length=1048576, flags=0)],
-        "qemu:allocation-depth": [nbd.Extent(length=1048576, flags=0)],
-    }
+    assert extents["base:allocation"] == [
+        nbd.Extent(length=1048576, flags=0),
+    ]
+
+    if fmt != "raw":
+        assert extents["qemu:allocation-depth"] == [
+            nbd.Extent(length=1048576, flags=0),
+        ]


### PR DESCRIPTION
When using a thread pool we try to reuse the connection backend by
passing the connection backend to the first worker instead of cloning
it. This introduce some issues:

- The backend is closed twice: once by the worker, and again by the
  connection. This is safe since closing backend twice does nothing, but
  dirty. Will break if we try to use the backend after a copy.

- With very small images, the first worker may close the original
  backend before another worker try to clone it. This is unlikely to
  happen with real images but can break the tests.

Fix the issues by introducing a backend wrapper, overriding close() to
disconnect from the wrapped backend instead of closing it. This ensures
that dst is never closed before it is cloned, and that it is closed
exactly once.

Another approach to fix this is to close the initial backend used for
preparing a copy, and pass the backends open argument to io.copy(), and
open new backends in the workers without all the hacks. This requires
lot of work, so I'm staring with this minimal change.

Fixes #23 