### PR TITLE
Replace ticket id with transfer id

### DIFF
--- a/ovirt_imageio/_internal/auth.py
+++ b/ovirt_imageio/_internal/auth.py
@@ -51,6 +51,12 @@ class Ticket:
                 "Unsupported url scheme: %s" % self._url.scheme)
 
         self._transfer_id = _optional(ticket_dict, "transfer_id", str)
+
+        # Engine before 4.2.7 did not pass the transfer id. Generate a likey
+        # unique value from the first half of the uuid.
+        if self._transfer_id is None:
+            self._transfer_id = f"(ticket/{self._uuid[:18]})"
+
         self._filename = _optional(ticket_dict, "filename", str)
         self._sparse = _optional(ticket_dict, "sparse", bool, default=False)
         self._dirty = _optional(ticket_dict, "dirty", bool, default=False)

--- a/ovirt_imageio/_internal/errors.py
+++ b/ovirt_imageio/_internal/errors.py
@@ -50,11 +50,11 @@ class AuthorizationError(Error):
         self.reason = reason
 
 
-class TicketCancelTimeout(Error):
-    msg = "Timeout cancelling ticket {self.ticket_id}"
+class TransferCancelTimeout(Error):
+    msg = "Timeout cancelling transfer {self.transfer_id}"
 
-    def __init__(self, ticket_id):
-        self.ticket_id = ticket_id
+    def __init__(self, transfer_id):
+        self.transfer_id = transfer_id
 
 
 class UnsupportedOperation(Error):

--- a/ovirt_imageio/_internal/handlers/checksum.py
+++ b/ovirt_imageio/_internal/handlers/checksum.py
@@ -69,8 +69,8 @@ class Checksum:
         except errors.AuthorizationError as e:
             raise http.Error(http.FORBIDDEN, str(e))
 
-        log.info("[%s] CHECKSUM ticket=%s algorithm=%s block_size=%s",
-                 req.client_addr, ticket_id, algorithm, block_size)
+        log.info("[%s] CHECKSUM transfer=%s algorithm=%s block_size=%s",
+                 req.client_addr, ticket.transfer_id, algorithm, block_size)
 
         # For simplicity we create a new buffer even if block_size is same as
         # ctx.buffer length.

--- a/ovirt_imageio/_internal/handlers/extents.py
+++ b/ovirt_imageio/_internal/handlers/extents.py
@@ -43,8 +43,8 @@ class Handler:
             raise http.Error(
                 http.NOT_FOUND, "Ticket does not support dirty extents")
 
-        log.info("[%s] EXTENTS ticket=%s context=%s",
-                 req.client_addr, ticket_id, context)
+        log.info("[%s] EXTENTS transfer=%s context=%s",
+                 req.client_addr, ticket.transfer_id, context)
 
         with req.clock.run("extents"):
             try:

--- a/test/auth_test.py
+++ b/test/auth_test.py
@@ -324,8 +324,10 @@ def test_dirty(cfg):
 
 
 def test_transfer_id_unset(cfg):
-    ticket = Ticket(testutil.create_ticket(), cfg)
-    assert ticket.transfer_id is None
+    d = testutil.create_ticket()
+    del d["transfer_id"]
+    ticket = Ticket(d, cfg)
+    assert ticket.transfer_id == f"(ticket/{ticket.uuid[:18]})"
 
 
 def test_transfer_id(cfg):

--- a/test/auth_test.py
+++ b/test/auth_test.py
@@ -405,7 +405,7 @@ def test_cancel_timeout(cfg):
     ticket._add_operation(Operation(0, 100))
 
     # Canceling will time out.
-    with pytest.raises(errors.TicketCancelTimeout):
+    with pytest.raises(errors.TransferCancelTimeout):
         ticket.cancel(timeout=0.001)
 
     # Ticket is marked as canceled, but the context was not closed.
@@ -660,7 +660,7 @@ def test_authorizer_remove_timeout(cfg):
     cfg.control.remove_timeout = 0.001
 
     # Ticket cannot be removed since it is used by connection 1.
-    with pytest.raises(errors.TicketCancelTimeout):
+    with pytest.raises(errors.TransferCancelTimeout):
         auth.remove(ticket.uuid)
 
     # Ticket was not removed.

--- a/test/handlers/tickets_test.py
+++ b/test/handlers/tickets_test.py
@@ -54,7 +54,7 @@ def test_no_method(srv):
 
 def test_get(srv, fake_time):
     ticket = testutil.create_ticket(
-        ops=["read"], sparse=False, dirty=False, transfer_id="123")
+        ops=["read"], sparse=False, dirty=False)
     srv.auth.add(ticket)
     fake_time.now += 200
     with http.ControlClient(srv.config) as c:

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -46,9 +46,8 @@ def create_ticket(uuid=None, ops=None, timeout=300, size=2**64,
         "ops": ["read", "write"] if ops is None else ops,
         "size": size,
         "url": url,
+        "transfer_id": transfer_id or str(uuid4()),
     }
-    if transfer_id is not None:
-        d["transfer_id"] = transfer_id
     if filename is not None:
         d["filename"] = filename
     if sparse is not None:


### PR DESCRIPTION
Log the transfer id instead of the ticket id for easier debugging.
The transfer id is already used in other components for tracking 
a transfer.

Fixes #26.