### PR TITLE
ovirt-img: Improve error handling and documention

### DIFF
--- a/ovirt-img/nbd/nbd.go
+++ b/ovirt-img/nbd/nbd.go
@@ -151,8 +151,9 @@ func (b *Backend) blockStatus(offset, length uint64) ([]uint32, error) {
 		return 0
 	}
 
-	// BlockStatus may fail randomly, looks like bug in libnbd.
-	// https://listman.redhat.com/archives/libguestfs/2021-October/msg00113.html
+	// BlockStatus may fail randomly with EINTR. Fixed in libnbd 1.10.2
+	// https://gitlab.com/nbdkit/libnbd/-/commit/48136328150bc587178091b5766bda382158cb6c
+	// TODO remove when we require libnbd >= 1.10.2.
 	for {
 		err := b.h.BlockStatus(length, offset, cb, nil)
 		if err == nil {

--- a/ovirt-img/nbd/nbd.go
+++ b/ovirt-img/nbd/nbd.go
@@ -144,10 +144,8 @@ func (b *Backend) blockStatus(offset, length uint64) ([]uint32, error) {
 	var result []uint32
 
 	cb := func(metacontext string, offset uint64, e []uint32, error *int) int {
-		if *error != 0 {
-			panic("expected *error == 0")
-		}
-		if metacontext == "base:allocation" {
+		// blockStatus() will fail on non zero *error.
+		if metacontext == "base:allocation" && *error == 0 {
 			result = e
 		}
 		return 0


### PR DESCRIPTION
- Exit with clear error instead of panic if extent callback failed
- Improve comment about EINTR in blockStatus()