### PR TITLE
Speed up ranges calculations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build:
 	python3 setup.py build_ext --inplace
 
 check:
-	tox -e "flake8,test-{py36,py37,py38,py39,py310}"
+	tox
 
 dist: $(GENERATED)
 	python3 setup.py sdist --dist-dir "$(OUTDIR)"

--- a/ovirt_imageio/_internal/measure.py
+++ b/ovirt_imageio/_internal/measure.py
@@ -16,7 +16,11 @@ class Range:
         self.end = end
 
     def __lt__(self, other):
-        return (self.start, self.end) < (other.start, other.end)
+        if self.start < other.start:
+            return True
+        if self.start == other.start:
+            return self.end < other.end
+        return False
 
     def __len__(self):
         return self.end - self.start

--- a/ovirt_imageio/_internal/measure.py
+++ b/ovirt_imageio/_internal/measure.py
@@ -9,6 +9,8 @@
 
 class Range:
 
+    __slots__ = ("start", "end")
+
     def __init__(self, start, end):
         self.start = start
         self.end = end
@@ -24,8 +26,8 @@ class Range:
                 self.start == other.start and
                 self.end == other.end)
 
-    def __ne__(self, other):
-        return not self == other
+    def __repr__(self):
+        return f"Range(start={self.start}, end={self.end})"
 
 
 def merge_ranges(ranges):

--- a/test/auth_test.py
+++ b/test/auth_test.py
@@ -340,31 +340,31 @@ def test_run_benchmark(cfg, workers, client_class):
 
 
 @pytest.mark.benchmark
-@pytest.mark.parametrize("concurrent", [1, 2, 4, 8])
-def test_transferred_benchmark(concurrent, cfg):
+@pytest.mark.parametrize("workers", [1, 2, 4, 8])
+def test_transferred_benchmark(cfg, workers):
     # Time trransferred call with multiple ongoing and completed operations.
     ticket = Ticket(testutil.create_ticket(ops=["read"]), cfg)
 
-    calls = 10000
+    ops = 10000
 
     # Add some completed ranges - assume worst case when ranges are not
     # continues.
-    for i in range(concurrent):
+    for i in range(workers):
         ticket.run(Operation(i * 1000, 100))
 
     # Add some ongoing operations - assume worst case when ranges are not
     # continues.
-    for i in range(concurrent):
+    for i in range(workers):
         ticket._add_operation(Operation(i * 1000 + 200, 100))
 
     # Time transferred call - merging ongoing and completed ranges.
     start = time.monotonic()
-    for i in range(calls):
+    for i in range(ops):
         ticket.transferred()
     elapsed = time.monotonic() - start
 
-    print("%d concurrent operations, %d calls in %.3f seconds (%d nsec/op)"
-          % (concurrent, calls, elapsed, elapsed * 10**9 // calls))
+    print("%d workers, %d ops, %.3f s, %.2f ops/s"
+          % (workers, ops, elapsed, ops / elapsed))
 
 
 @pytest.mark.parametrize("arg", [

--- a/test/measure_test.py
+++ b/test/measure_test.py
@@ -6,10 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import pytest
-
-from ovirt_imageio._internal import measure
-from ovirt_imageio._internal.measure import Range
+from ovirt_imageio._internal.measure import Range, RangeList
 
 # Compare ranges.
 
@@ -32,34 +29,235 @@ def test_ragne_ne():
     assert Range(5, 10) != Range(15, 20)
 
 
-@pytest.mark.parametrize("orig_ranges,merged_ranges", [
-    # No range
-    ([], []),
+# Add to range list
 
-    # Single range
-    ([(5, 10)], [(5, 10)]),
 
-    # Two consecutive ranges.
-    ([(5, 10), (10, 20)], [(5, 20)]),
+def test_range_list_empty():
+    rl = RangeList()
+    assert rl.sum() == 0
 
-    # Two ranges with a "hole" in between.
-    ([(5, 10), (15, 20)], [(5, 10), (15, 20)]),
 
-    # Two overlapping ranges.
-    ([(5, 10), (5, 20)], [(5, 20)]),
+def test_range_list_add_first():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    assert rl._ranges == [Range(0, 10)]
+    assert rl.sum() == 10
 
-    # Three unsorted and partially overlapping ranges.
-    ([(5, 10), (0, 3), (7, 20)],
-     [(0, 3), (5, 20)]),
 
-    # Three separate ranges.
-    ([(5, 10), (15, 20), (25, 30)],
-     [(5, 10), (15, 20), (25, 30)]),
+def test_range_list_add_same():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(0, 10))
+    assert rl._ranges == [Range(0, 10)]
+    assert rl.sum() == 10
 
-    # Three unsorted and overlapping ranges.
-    ([(5, 10), (0, 5), (10, 20)], [(0, 20)]),
-])
-def test_merge_ranges(orig_ranges, merged_ranges):
-    orig_ranges = [Range(start, end) for start, end in orig_ranges]
-    merged_ranges = [Range(start, end) for start, end in merged_ranges]
-    assert measure.merge_ranges(orig_ranges) == merged_ranges
+
+def test_range_list_add_shorter():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(0, 5))
+    assert rl._ranges == [Range(0, 10)]
+    assert rl.sum() == 10
+
+
+def test_range_list_add_longer():
+    rl = RangeList()
+    rl.add(Range(0, 5))
+    rl.add(Range(0, 10))
+    assert rl._ranges == [Range(0, 10)]
+    assert rl.sum() == 10
+
+
+def test_range_list_add_overlap():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(5, 15))
+    assert rl._ranges == [Range(0, 15)]
+    assert rl.sum() == 15
+
+
+def test_range_list_add_contiguous():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(10, 20))
+    assert rl._ranges == [Range(0, 20)]
+    assert rl.sum() == 20
+
+
+def test_range_list_add_non_contiguous():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    assert rl._ranges == [Range(0, 10), Range(20, 30)]
+    assert rl.sum() == 20
+
+
+def test_ragne_list_add_overlap_next_some():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    rl.add(Range(15, 25))
+    assert rl._ranges == [Range(0, 10), Range(15, 30)]
+    assert rl.sum() == 25
+
+
+def test_ragne_list_add_overlap_next_all():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    rl.add(Range(15, 30))
+    assert rl._ranges == [Range(0, 10), Range(15, 30)]
+    assert rl.sum() == 25
+
+
+def test_range_list_add_overlap_both_some():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    rl.add(Range(5, 25))
+    assert rl._ranges == [Range(0, 30)]
+    assert rl.sum() == 30
+
+
+def test_range_list_add_overlap_both_all():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    rl.add(Range(0, 30))
+    assert rl._ranges == [Range(0, 30)]
+    assert rl.sum() == 30
+
+
+def test_range_list_add_overlap_next_multi_some():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    rl.add(Range(40, 50))
+    rl.add(Range(60, 70))
+    rl.add(Range(25, 45))
+    assert rl._ranges == [Range(0, 10), Range(20, 50), Range(60, 70)]
+    assert rl.sum() == 50
+
+
+def test_range_list_add_overlap_next_multi_all():
+    rl = RangeList()
+    rl.add(Range(0, 10))
+    rl.add(Range(20, 30))
+    rl.add(Range(40, 50))
+    rl.add(Range(60, 70))
+    rl.add(Range(20, 50))
+    assert rl._ranges == [Range(0, 10), Range(20, 50), Range(60, 70)]
+    assert rl.sum() == 50
+
+
+# Update range list.
+
+
+def test_range_list_update_first():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(10, 20), Range(20, 30), Range(30, 40)])
+    assert rl._ranges == [Range(0, 40)]
+    assert rl.sum() == 40
+
+
+def test_range_list_update_same():
+    rl = RangeList()
+    rl.add(Range(0, 40))
+    rl.update([Range(0, 10), Range(10, 20), Range(20, 30), Range(30, 40)])
+    assert rl._ranges == [Range(0, 40)]
+    assert rl.sum() == 40
+
+
+def test_range_list_update_contiguous():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(100, 110), Range(200, 210)])
+    rl.update([Range(10, 20), Range(110, 120), Range(210, 220)])
+    assert rl._ranges == [Range(0, 20), Range(100, 120), Range(200, 220)]
+    assert rl.sum() == 60
+
+
+def test_range_list_update_non_contiguous():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(100, 110), Range(200, 210)])
+    rl.update([Range(300, 310), Range(400, 410), Range(500, 510)])
+    assert rl._ranges == [
+        Range(0, 10),
+        Range(100, 110),
+        Range(200, 210),
+        Range(300, 310),
+        Range(400, 410),
+        Range(500, 510),
+    ]
+    assert rl.sum() == 60
+
+
+def test_ragne_list_update_overlap_next_some():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(20, 30)])
+    rl.update([Range(15, 25)])
+    assert rl._ranges == [Range(0, 10), Range(15, 30)]
+    assert rl.sum() == 25
+
+
+def test_ragne_list_update_overlap_next_all():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(20, 30)])
+    rl.update([Range(15, 30)])
+    assert rl._ranges == [Range(0, 10), Range(15, 30)]
+    assert rl.sum() == 25
+
+
+def test_range_list_update_overlap_both_some():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(20, 30)])
+    rl.update([Range(5, 25)])
+    assert rl._ranges == [Range(0, 30)]
+    assert rl.sum() == 30
+
+
+def test_range_list_update_overlap_both_all():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(20, 30)])
+    rl.update([Range(0, 30)])
+    assert rl._ranges == [Range(0, 30)]
+    assert rl.sum() == 30
+
+
+def test_range_list_update_overlap_next_multi_some():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(20, 30), Range(40, 50), Range(60, 70)])
+    rl.update([Range(5, 35), Range(25, 65)])
+    assert rl._ranges == [Range(0, 70)]
+    assert rl.sum() == 70
+
+
+def test_range_list_update_overlap_next_multi_all():
+    rl = RangeList()
+    rl.update([Range(0, 10), Range(20, 30), Range(40, 50), Range(60, 70)])
+    rl.update([Range(0, 50), Range(20, 70)])
+    assert rl._ranges == [Range(0, 70)]
+    assert rl.sum() == 70
+
+
+# Copy range list.
+
+
+def test_range_list_copy():
+    r1 = RangeList()
+
+    r1.add(Range(0, 100))
+    r1.add(Range(200, 300))
+    r1.add(Range(400, 500))
+
+    r2 = RangeList(r1)
+
+    # r1 and r2 are qqual.
+    assert r1._ranges == r2._ranges
+    assert r1.sum() == r2.sum()
+
+    # But independent.
+    r1.add(Range(300, 400))
+    r2.add(Range(100, 200))
+
+    assert r1._ranges == [Range(0, 100), Range(200, 500)]
+    assert r2._ranges == [Range(0, 300), Range(400, 500)]

--- a/test/measure_test.py
+++ b/test/measure_test.py
@@ -11,83 +11,25 @@ import pytest
 from ovirt_imageio._internal import measure
 from ovirt_imageio._internal.measure import Range
 
+# Compare ranges.
 
-class TestRange:
 
-    """
-    To make the cases visual, each test case is described using two ranges:
-    - The range that change in each test case is drawn as follows: "*****".
-    - The range that we compare the others to is drawn as follows: "-----".
-    """
-    @pytest.mark.parametrize("start,end,expected", [
-        #          *****
-        #     -----
-        (15, 20, True),
+def test_range_lt_start_smaller():
+    assert Range(5, 10) < Range(6, 10)
+    assert not Range(6, 10) < Range(5, 10)
 
-        #         *****
-        #     -----
-        (10, 20, True),
 
-        #         *
-        #     -----
-        (10, 10, True),
+def test_range_lt_start_same():
+    assert Range(5, 10) < Range(5, 11)
+    assert not Range(5, 11) < Range(5, 10)
 
-        #       *****
-        #     -----
-        (7, 20, True),
 
-        #       ***
-        #     -----
-        (7, 10, True),
+def test_range_eq():
+    assert Range(5, 10) == Range(5, 10)
 
-        #      ***
-        #     -----
-        (7, 8, True),
 
-        #     *******
-        #     -----
-        (5, 15, True),
-
-        #     *****
-        #     -----
-        (5, 10, False),
-
-        #     ***
-        #     -----
-        (5, 8, False),
-
-        #     *
-        #     -----
-        (5, 5, False),
-
-        #   *********
-        #     -----
-        (3, 15, False),
-
-        #   *******
-        #     -----
-        (3, 10, False),
-
-        # *****
-        #     -----
-        (3, 5, False),
-
-        #   *****
-        #     -----
-        (3, 8, False),
-
-        # ***
-        #     -----
-        (3, 4, False),
-    ])
-    def test_lt(self, start, end, expected):
-        assert (Range(5, 10) < Range(start, end)) == expected
-
-    def test_eq(self):
-        assert Range(5, 10) == Range(5, 10)
-
-    def test_ne(self):
-        assert Range(5, 10) != Range(15, 20)
+def test_ragne_ne():
+    assert Range(5, 10) != Range(15, 20)
 
 
 @pytest.mark.parametrize("orig_ranges,merged_ranges", [

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     python setup.py build_ext --inplace
     python -c 'from test import testutil; print("ipv6 supported: %s" % testutil.ipv6_enabled())'
     test: pytest -m 'not benchmark' --cov=ovirt_imageio --durations=10 {posargs}
-    bench: pytest -m 'benchmark' -s {posargs}
+    bench: pytest -m 'benchmark' -vs {posargs}
 
 [testenv:flake8]
 sitepackages = False


### PR DESCRIPTION
Speed up ranges calculations when completing requests and computing transferred size.

- Make it easier to run the benchmarks
- Improve the benchmarks simulating real transfer with 2 kinds of clients (nbdcopy, imageio)
- Improve benchmarks output
- Improve measure tests
- Remove python 2 only `Range.__ne__`
- Add `Range.__repr__` for easier debugging
- Add `Range.__slots__` to minimize Range creation time
- Speed up `Range.__lt__`
- Remove unneeded sorting during merge
- Add `RangeList` class for managing ranges

The actual speedup is very small, but the code is cleaner and easier to maintain.

Fixes #29.