### PR TITLE
auth: Don't track ranges for read-write ticket

### DIFF
--- a/ovirt_imageio/_internal/auth.py
+++ b/ovirt_imageio/_internal/auth.py
@@ -224,8 +224,10 @@ class Ticket:
                 raise errors.AuthorizationError(
                     "Transfer {} was canceled".format(self.transfer_id))
 
-            r = measure.Range(op.offset, op.offset + op.done)
-            self._completed.add(r)
+            # We don't report transfered bytes for read-write ticket.
+            if len(self.ops) == 1:
+                r = measure.Range(op.offset, op.offset + op.done)
+                self._completed.add(r)
 
         self.touch()
 


### PR DESCRIPTION
When using read-write ticket, we don't report the number of transferred
bytes, so there is no point to track the ranges.

This is so far the biggest optimization, lowering the overhead per
request by 20%. However since engine never use read-write mode, this
does not improve real flows.

The most important benefit is proving that additional optimization in
measuring ranges is not effective, since 80% of the time is spent
elsewhere.

```
test_run_benchmark[ro-nbdcopy-1] 1 workers, 25600 ops, 1.884 s, 13588.32 ops/s
test_run_benchmark[ro-nbdcopy-2] 2 workers, 25600 ops, 2.229 s, 11483.24 ops/s
test_run_benchmark[ro-nbdcopy-4] 4 workers, 25600 ops, 2.305 s, 11104.09 ops/s
test_run_benchmark[ro-nbdcopy-8] 8 workers, 25600 ops, 2.410 s, 10623.58 ops/s
test_run_benchmark[ro-imageio-1] 1 workers, 25600 ops, 1.896 s, 13505.05 ops/s
test_run_benchmark[ro-imageio-2] 2 workers, 25600 ops, 2.270 s, 11275.83 ops/s
test_run_benchmark[ro-imageio-4] 4 workers, 25600 ops, 2.269 s, 11280.55 ops/s
test_run_benchmark[ro-imageio-8] 8 workers, 25600 ops, 2.361 s, 10841.85 ops/s
test_run_benchmark[rw-nbdcopy-1] 1 workers, 25600 ops, 1.786 s, 14332.42 ops/s
test_run_benchmark[rw-nbdcopy-2] 2 workers, 25600 ops, 2.188 s, 11700.01 ops/s
test_run_benchmark[rw-nbdcopy-4] 4 workers, 25600 ops, 2.098 s, 12204.83 ops/s
test_run_benchmark[rw-nbdcopy-8] 8 workers, 25600 ops, 1.932 s, 13247.69 ops/s
test_run_benchmark[rw-imageio-1] 1 workers, 25600 ops, 1.719 s, 14895.74 ops/s
test_run_benchmark[rw-imageio-2] 2 workers, 25600 ops, 2.353 s, 10881.34 ops/s
test_run_benchmark[rw-imageio-4] 4 workers, 25600 ops, 2.192 s, 11679.60 ops/s
test_run_benchmark[rw-imageio-8] 8 workers, 25600 ops, 2.192 s, 11677.66 ops/s
```

Signed-off-by: Nir Soffer <nsoffer@redhat.com>