### PR TITLE
Add profiling support

### DIFF
--- a/ovirt_imageio/_internal/qemu_nbd.py
+++ b/ovirt_imageio/_internal/qemu_nbd.py
@@ -191,7 +191,7 @@ class Server:
 
 
 @contextmanager
-def run(image, fmt, sock, export_name="", read_only=False, shared=1,
+def run(image, fmt, sock, export_name="", read_only=False, shared=8,
         cache="none", aio="native", discard="unmap", detect_zeroes="unmap",
         bitmap=None, backing_chain=True, offset=None, size=None, timeout=10.0):
     server = Server(

--- a/ovirt_imageio/admin/_api.py
+++ b/ovirt_imageio/admin/_api.py
@@ -119,6 +119,16 @@ class Client:
         if status != http.client.NO_CONTENT:
             raise ServerError(status, body)
 
+    def start_profile(self):
+        status, body = self._request("POST", "/profile/?run=y")
+        if status != http.client.OK:
+            raise ServerError(status, body)
+
+    def stop_profile(self):
+        status, body = self._request("POST", "/profile/?run=n")
+        if status != http.client.OK:
+            raise ServerError(status, body)
+
     def close(self):
         """
         Close the conection to imageio daemon.

--- a/ovirt_imageio/admin/tool.py
+++ b/ovirt_imageio/admin/tool.py
@@ -68,6 +68,18 @@ def main():
         "ticket_id",
         help="Ticket id.")
 
+    add_command(
+        commands,
+        name="start-profile",
+        help="Start server profiling",
+        command=start_profile)
+
+    add_command(
+        commands,
+        name="stop-profile",
+        help="Stop server profiling",
+        command=stop_profile)
+
     args = parser.parse_args()
     try:
         args.command(args)
@@ -113,3 +125,15 @@ def del_ticket(args):
     cfg = admin.load_config(args.conf_dir)
     with admin.Client(cfg) as c:
         c.del_ticket(args.ticket_id)
+
+
+def start_profile(args):
+    cfg = admin.load_config(args.conf_dir)
+    with admin.Client(cfg) as c:
+        c.start_profile()
+
+
+def stop_profile(args):
+    cfg = admin.load_config(args.conf_dir)
+    with admin.Client(cfg) as c:
+        c.stop_profile()


### PR DESCRIPTION
Make it easy to profile the server using the ovirt-imageioctl
tool or the admin client library.

Example usage:

    ovirt-imageioctl add-ticket examples/json
    ovirt-imageioctl start-profile
    examples/imageio-client upload src-image https://localhost:54322/images/nbd
    ovirt-imageioctl stop-profile

Not documented yet.