### PR TITLE
Zero detection in client side

### DIFF
--- a/bench/conf.d/daemon.conf
+++ b/bench/conf.d/daemon.conf
@@ -1,0 +1,28 @@
+# Configuration for benchmarking the server.
+#
+#    ./ovirt-imageio -c bench
+
+[backend_nbd]
+buffer_size = 262144
+#buffer_size = 524288
+#buffer_size = 1048576
+#buffer_size = 2097152
+#buffer_size = 4194304
+
+[tls]
+key_file = test/pki/system/key.pem
+cert_file = test/pki/system/cert.pem
+ca_file = test/pki/system/ca.pem
+
+[control]
+transport = unix
+socket = bench/daemon.sock
+
+[logger_root]
+level = INFO
+
+[handler_logfile]
+args = ("bench/daemon.log",)
+
+[profile]
+filename = bench/daemon.prof

--- a/bench/upload.json
+++ b/bench/upload.json
@@ -1,0 +1,9 @@
+{
+    "uuid": "upload",
+    "size": 6442450944,
+    "url": "nbd:unix:/tmp/nbd.sock",
+    "timeout": 3000,
+    "inactivity_timeout": 300,
+    "sparse": true,
+    "ops": ["write"]
+}

--- a/bench/upload.py
+++ b/bench/upload.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python3
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+from contextlib import contextmanager
+
+# TODO: Find a better way to use package from source, so we can remove the
+# "noqa" from the imports bellow.
+sys.path.insert(0, ".")
+
+from ovirt_imageio import admin  # noqa: E402
+from ovirt_imageio._internal import nbd  # noqa: E402
+from ovirt_imageio._internal import qemu_img  # noqa: E402
+from ovirt_imageio._internal import qemu_nbd  # noqa: E402
+
+CONF = "bench"
+NBD_SOCK = os.path.abspath("bench/ndb.sock")
+TICKET = "bench/upload.json"
+
+# Use different drives for source and destiantion image for best results.
+SRC_IMG = "/data/scratch/fedora-35-data.raw"
+DST_IMG = "/data/tmp/dst.raw"
+
+IMG_SIZE = 6*1024**3
+TRANSFER_URL = "https://localhost:54322/images/upload"
+
+# Consume NVMe drives quickly slow down after writing few GiBs. Waiting for the
+# drive to cool down before running the test keeps results stable. If you have
+# enterprize grade drive, you can set this to 0.
+COOLDOWN_DELAY = 30
+
+# Use higher value for more reliable results.
+RUNS = 3
+
+profile = False
+
+
+@contextmanager
+def imageio_server(conf):
+    server = subprocess.Popen(["./ovirt-imageio", "--conf-dir", conf])
+    try:
+        # TODO: wait for server socket.
+        time.sleep(1)
+        yield
+    finally:
+        server.terminate()
+        server.wait()
+
+
+cfg = admin.load_config("bench")
+
+qemu_img.create(DST_IMG, "raw", size=IMG_SIZE)
+
+with qemu_nbd.run(DST_IMG, "raw", nbd.UnixAddress(NBD_SOCK)), \
+        imageio_server(CONF), \
+        admin.Client(cfg) as adm:
+
+    with open(TICKET) as f:
+        data = f.read()
+    ticket = json.loads(data)
+    ticket["url"] = f"nbd:unix:{NBD_SOCK}"
+    ticket["size"] = IMG_SIZE
+
+    adm.add_ticket(ticket)
+
+    if profile:
+        adm.start_profile()
+
+    # NOTE: Without --show-output hyperfine seems to show ~0.2s extra
+    # time which is a lot when uploading small images, and displayed
+    # time is much less stable (e.g. +-0.257 vs +-0.028).
+
+    cmd = [
+        "hyperfine",
+        "--runs", f"{RUNS}",
+        "--prepare", f"sleep {COOLDOWN_DELAY}",
+        "--parameter-list", "b", "256,512,1024,2048,4096,8192",
+        "--show-output",
+        "examples/imageio-client --insecure --quiet --buffer-size={b} "
+        f"upload {SRC_IMG} {TRANSFER_URL}"
+    ]
+    subprocess.run(cmd, check=True)
+
+    if profile:
+        adm.stop_profile()

--- a/examples/imageio-client
+++ b/examples/imageio-client
@@ -192,11 +192,14 @@ Finally shutdown qmeu-nbd in the other shell.
 import argparse
 import logging
 
+from contextlib import contextmanager
+
 from ovirt_imageio import client
 
 
 def upload(args):
-    with client.ProgressBar() as pb:
+    progress = quiet if args.quiet else client.ProgressBar
+    with progress() as pb:
         client.upload(
             args.filename,
             args.url,
@@ -208,7 +211,8 @@ def upload(args):
 
 
 def download(args):
-    with client.ProgressBar() as pb:
+    progress = quiet if args.quiet else client.ProgressBar
+    with progress() as pb:
         client.download(
             args.url,
             args.filename,
@@ -219,6 +223,11 @@ def download(args):
             max_workers=args.max_workers,
             secure=args.secure,
             progress=pb)
+
+
+@contextmanager
+def quiet():
+    yield None
 
 
 parser = argparse.ArgumentParser(description="imageio client")
@@ -252,6 +261,11 @@ parser.add_argument(
     "-v", "--verbose",
     action="store_true",
     help="Be more verbose")
+
+parser.add_argument(
+    "-q", "--quiet",
+    action="store_true",
+    help="Be quiet, do not show progress bar")
 
 commands = parser.add_subparsers(title="commands")
 

--- a/examples/imageio-client
+++ b/examples/imageio-client
@@ -207,6 +207,7 @@ def upload(args):
             buffer_size=args.buffer_size,
             max_workers=args.max_workers,
             secure=args.secure,
+            detect_zeroes=args.detect_zeroes,
             progress=pb)
 
 
@@ -279,6 +280,11 @@ upload_parser.add_argument(
 upload_parser.add_argument(
     "url",
     help="transfer URL")
+upload_parser.add_argument(
+    "-z", "--detect-zeroes",
+    action="store_true",
+    help="Try to sparsify the image. May slow down upload of a sparse "
+         "image but speed up upload of fully allocated image.")
 
 download_parser = commands.add_parser(
     "download",

--- a/ovirt_imageio/client/_api.py
+++ b/ovirt_imageio/client/_api.py
@@ -32,7 +32,7 @@ log = logging.getLogger("client")
 
 def upload(filename, url, cafile, buffer_size=io.BUFFER_SIZE, secure=True,
            progress=None, proxy_url=None, max_workers=io.MAX_WORKERS,
-           member=None, backing_chain=True):
+           member=None, backing_chain=True, detect_zeroes=False):
     """
     Upload filename to url
 
@@ -62,6 +62,8 @@ def upload(filename, url, cafile, buffer_size=io.BUFFER_SIZE, secure=True,
             image data, leaving unallocated areas as holes, exposing data from
             the target disk backing chain. Valid only when uploding to an empty
             snapshot.
+        detect_zeroes (bool): Try to sparsify the image. May slow down upload
+            of sparse image, but speed up upload of fully allocated images.
     """
     if callable(progress):
         progress = ProgressWrapper(progress)
@@ -104,6 +106,7 @@ def upload(filename, url, cafile, buffer_size=io.BUFFER_SIZE, secure=True,
                 # has a backing chain. We must keep holes unallocated on the so
                 # they expose data from the backing chain.
                 hole=backing_chain,
+                detect_zeroes=detect_zeroes,
                 progress=progress,
                 name="upload")
 


### PR DESCRIPTION
This is experimental work on zero detection in client side. Some images
may contain zeroes in data extents. Currently we send these extents as
data, and qemu-nbd detect zeroes and convert them to hole or allocated
area.

Detecting zeroes on client side is much more efficient; instead of sending
zeroes over the wire, we send a tiny zero request without any payload.
Practically this is very hard to do while using the http optimized code that
try to minimize the number of http requests.

I implemented zero detection in a very simplistic way. Testing show small
improvement in the best case, fully allocated image full of zeroes, and
large slowdown when uploading real images.

Zero detection can be useful when uploading over very slow network. I did
not test this case yet.

Unfinished:
- Add upload benchmarks
- Should we adapt buffer size automatically if --detect-zeroes is set, and
  --buffer-size was not set?
- Is is possible to implement in a better way by buffering more data in the
  copy loop?

Fixes #37 