### PR TITLE
ovirt-img: Upgrade libnbd to v1.12.0

### DIFF
--- a/ovirt-img/go.mod
+++ b/ovirt-img/go.mod
@@ -6,6 +6,6 @@ replace ovirt.org/imageio => ../go
 go 1.16
 
 require (
-	libguestfs.org/libnbd v1.11.5
+	libguestfs.org/libnbd v1.12.0
 	ovirt.org/imageio v0.0.0-00010101000000-000000000000
 )

--- a/ovirt-img/go.sum
+++ b/ovirt-img/go.sum
@@ -1,4 +1,4 @@
-libguestfs.org/libnbd v1.11.3-4-g3226ff802 h1:7ZNhVreHSeHS+aK1PXPZvcHY43ikvAnoFDE9blNSQ3E=
-libguestfs.org/libnbd v1.11.3-4-g3226ff802/go.mod h1:Qd8vaULc6nlNgj9+6qDNm1vSD/J7/wgoIlwmCh8uxAc=
 libguestfs.org/libnbd v1.11.5 h1:jRCRxzbeZksdj6e3sp+5/vfDfWx1s/uYyJB0qjgb8MI=
 libguestfs.org/libnbd v1.11.5/go.mod h1:Qd8vaULc6nlNgj9+6qDNm1vSD/J7/wgoIlwmCh8uxAc=
+libguestfs.org/libnbd v1.12.0 h1:nf5JC6NKdBPhpksHZjUrvsxZf6C7bcMUyHc4z8+i4co=
+libguestfs.org/libnbd v1.12.0/go.mod h1:Qd8vaULc6nlNgj9+6qDNm1vSD/J7/wgoIlwmCh8uxAc=


### PR DESCRIPTION
This is the first stable release of the Go bindings.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>