### PR TITLE
backends: Log open and close in debug level

### DIFF
--- a/ovirt_imageio/_internal/backends/file.py
+++ b/ovirt_imageio/_internal/backends/file.py
@@ -62,8 +62,8 @@ class Backend:
             fio (io.FileIO): underlying file object.
             sparse (bool): deallocate space when zeroing if possible.
         """
-        log.info("Open backend path=%r mode=%r sparse=%r max_connections=%r",
-                 fio.name, fio.mode, sparse, max_connections)
+        log.debug("Open path=%r mode=%r sparse=%r max_connections=%r",
+                  fio.name, fio.mode, sparse, max_connections)
         self._fio = fio
         self._sparse = sparse
         self._dirty = False
@@ -112,8 +112,8 @@ class Backend:
 
     def close(self):
         if self._fio is not CLOSED:
-            log.info("Close backend path=%r dirty=%r",
-                     self._fio.name, self._dirty)
+            log.debug("Close path=%r dirty=%r",
+                      self._fio.name, self._dirty)
             try:
                 self._fio.close()
             finally:

--- a/ovirt_imageio/_internal/backends/http.py
+++ b/ovirt_imageio/_internal/backends/http.py
@@ -54,8 +54,8 @@ class Backend:
 
     def __init__(self, url, cafile=None, secure=True, connect_timeout=10,
                  read_timeout=60, connect=True):
-        log.info("Open backend netloc=%r path=%r cafile=%r secure=%r",
-                 url.netloc, url.path, cafile, secure)
+        log.debug("Open netloc=%r path=%r cafile=%r secure=%r",
+                  url.netloc, url.path, cafile, secure)
         self.url = url
         self._cafile = cafile
         self._secure = secure
@@ -339,8 +339,8 @@ class Backend:
 
     def close(self):
         if self._con is not CLOSED:
-            log.info("Close backend netloc=%r path=%r",
-                     self.url.netloc, self.url.path)
+            log.debug("Close netloc=%r path=%r",
+                      self.url.netloc, self.url.path)
             self._con.close()
             self._con = CLOSED
 

--- a/ovirt_imageio/_internal/backends/memory.py
+++ b/ovirt_imageio/_internal/backends/memory.py
@@ -41,8 +41,8 @@ class Backend:
     def __init__(self, mode="r", data=None, max_connections=8, extents=None):
         if mode not in ("r", "w", "r+"):
             raise ValueError("Unsupported mode %r" % mode)
-        log.info("Open backend mode=%r max_connections=%r",
-                 mode, max_connections)
+        log.debug("Open mode=%r max_connections=%r",
+                  mode, max_connections)
         self._mode = mode
         self._buf = data or bytearray()
         # TODO: Make size constant so we can build the default extents here.
@@ -121,7 +121,7 @@ class Backend:
         self._dirty = False
 
     def close(self):
-        log.info("Close backend")
+        log.debug("Close")
         self._closed = True
 
     def __enter__(self):

--- a/ovirt_imageio/_internal/backends/nbd.py
+++ b/ovirt_imageio/_internal/backends/nbd.py
@@ -60,9 +60,9 @@ class Backend:
     def __init__(self, client, mode="r", sparse=False, max_connections=8):
         if mode not in ("r", "w", "r+"):
             raise ValueError("Unsupported mode %r" % mode)
-        log.info("Open backend address=%r export_name=%r sparse=%r "
-                 "max_connections=%r",
-                 client.address, client.export_name, sparse, max_connections)
+        log.debug("Open address=%r export_name=%r sparse=%r "
+                  "max_connections=%r",
+                  client.address, client.export_name, sparse, max_connections)
         self._client = client
         self._mode = mode
         self._sparse = sparse
@@ -148,7 +148,7 @@ class Backend:
 
     def close(self):
         if self._client is not CLOSED:
-            log.info("Close backend address=%r", self._client.address)
+            log.debug("Close address=%r", self._client.address)
             self._client.close()
             self._client = CLOSED
 


### PR DESCRIPTION
The open and close logs are mainly needed for debugging resource
management, but we logged them in INFO level. This is OK in the daemon
but problematic for the client code, crating unwanted noise in
application using the client library.

Tested using backup stress test.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>