### PR TITLE
qemu_nbd: Select cache and aio automatically

### DIFF
--- a/ovirt_imageio/client/_api.py
+++ b/ovirt_imageio/client/_api.py
@@ -480,13 +480,6 @@ def _open_nbd(filename, fmt, read_only=False, shared=1, bitmap=None,
               offset=None, size=None, backing_chain=True):
     """
     Open nbd backend.
-
-    Caching modes
-    -------------
-    qemu-nbd uses "writethrough" cache mode by default. This is
-    painfully slow and pointless, waiting until every write it flushed
-    to underlying storage. We use "writeback", waiting until data is
-    copied to the host page cache.
     """
     with _tmp_dir("imageio-") as base:
         sock = UnixAddress(os.path.join(base, "sock"))
@@ -495,8 +488,6 @@ def _open_nbd(filename, fmt, read_only=False, shared=1, bitmap=None,
                 fmt,
                 sock,
                 read_only=read_only,
-                cache="writeback",
-                aio=None,
                 shared=shared,
                 bitmap=bitmap,
                 offset=offset,


### PR DESCRIPTION
Previously we use --cache=writeback and --aio=threads so we can access
images on file system that does not support direct I/O. This is
sometimes faster than --cache=none and --aio=native, but typically give
less consistent results, and pollute the page cache with image data,
which is mostly likely will never be used.

When uploading and downloading images on a hypervisor, using the page
cache can be harmful and cause sanlock timeouts when the kernel try to
flush huge images to the underlying storage.

Future qemu-img and qemu-nbd are expected to implement "auto" cache and
aio modes, selecting --cache=none and --aio=native if possible. This
change implements this in our qemu_nbd wrapper so we can use this now
with current qemu version.

When starting qemu_nbd.Server(), if cache was not specified, we select
cache="none" if the image can be opened with direct I/O. If aio was not
specified, we select it based on the cache value.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>