### PR TITLE
Start 2.4.2 development cycle

### DIFF
--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -5,7 +5,7 @@ Summary:   oVirt imageio
 
 License:   GPLv2+
 Url:       https://github.com/oVirt/%{name}
-Source0:   http://resources.ovirt.org/pub/ovirt-master-snapshot/src/%{name}/%{name}-%{version}.tar.gz
+Source0:   https://github.com/oVirt/%{name}/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 %global ovirtimg_user ovirtimg
 %global srcname ovirt_imageio

--- a/ovirt_imageio/_internal/version.py
+++ b/ovirt_imageio/_internal/version.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-string = "2.4.1"
+string = "2.4.2"
 
 if __name__ == "__main__":
     print(string)


### PR DESCRIPTION
Start next development cycle for oVirt 4.5.0.

- Bump version to 2.4.2
- Fix source url in the spec

Signed-off-by: Nir Soffer <nsoffer@redhat.com>