### PR TITLE
docker: Add python 3.8 to el8 container

### DIFF
--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -18,10 +18,13 @@ RUN echo v1 \
         python3-devel \
         python3-pip \
         python3-systemd \
+        python38-devel \
+        python38-pip \
         qemu-img \
         qemu-kvm \
         rpm-build \
         sudo \
+        systemd-devel \
         systemd-udev \
         util-linux \
         xfsprogs \

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from distutils.core import setup
-from distutils.core import Extension
+from setuptools import setup
+from setuptools import Extension
 
 from ovirt_imageio._internal import version
 

--- a/test/backup_test.py
+++ b/test/backup_test.py
@@ -71,11 +71,12 @@ def test_full_backup(tmpdir, fmt, transport):
             assert d.read(i, 512) == b.read(512)
 
 
-# This can take more than 30 seoconds when running on Travis without hardware
-# acceleration:
-# 41.77s setup    test/backup_test.py::test_full_backup_guest
-# 17.59s call     test/backup_test.py::test_full_backup_guest
-@pytest.mark.timeout(120)
+# This times out randomly on gitub with 120 seconds timoeut. In this example
+# the test took about 60 seconds (setup + call) but in other runs the tests
+# timed out after 120 seconds.
+#   44.29s setup    test/backup_test.py::test_full_backup_guest
+#   15.94s call     test/backup_test.py::test_full_backup_guest
+@pytest.mark.timeout(180)
 @pytest.mark.xfail(
     ci.is_ovirt() or distro.is_centos("9"),
     reason="Always times out", run=False)
@@ -112,7 +113,7 @@ def test_full_backup_guest(tmpdir, base_image):
     verify_backup(backup_disk, ["before-backup"])
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 @pytest.mark.xfail(
     ci.is_ovirt() or distro.is_centos("9"),
     reason="Always times out", run=False)

--- a/tox.ini
+++ b/tox.ini
@@ -12,14 +12,17 @@ whitelist_externals =
 [testenv]
 passenv = *
 sitepackages = True
+usedevelop = True
 deps =
     test,bench: pytest
     test,bench: userstorage>=0.4
+    py38: systemd
     test: pytest-cov
     test: pytest-timeout
-commands =
-    python setup.py build_ext --inplace
+commands_pre =
+    python setup.py build_ext --build-lib .
     python -c 'from test import testutil; print("ipv6 supported: %s" % testutil.ipv6_enabled())'
+commands =
     test: pytest -m 'not benchmark' --cov=ovirt_imageio --durations=10 {posargs}
     bench: pytest -m 'benchmark' -vs {posargs}
 


### PR DESCRIPTION
We want to build also python 3.8 version of the common and client
packages, needed by ovirt python sdk. Adding python 3.8 to the container
enables the build and the tests.

python38-systemd is not available, hopefully this is a pure python
package and python3-systemd will works for the tests.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>