### PR TITLE
Testing and documentation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ METADATA = ovirt_imageio/_internal/version.py Makefile
 .PHONY: build check dist srpm rpm clean storage clean-storage $(SPEC_NAME)
 
 build:
-	python3 setup.py build_ext --inplace
+	python3 setup.py build_ext --build-lib .
 
 check:
 	tox

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ GENERATED = \
 
 METADATA = ovirt_imageio/_internal/version.py Makefile
 
-.PHONY: build check dist srpm rpm clean storage clean-storage $(SPEC_NAME)
+.PHONY: build check dist srpm rpm clean images clean-images storage clean-storage $(SPEC_NAME)
 
 build:
 	python3 setup.py build_ext --build-lib .
 
-check:
+check: images
 	tox
 
 dist: $(GENERATED)
@@ -40,6 +40,18 @@ clean:
 	rm -f ovirt_imageio/_internal/*.so
 	rm -rf build
 	rm -rf dist
+
+images: /var/tmp/imageio-images/cirros-0.3.5.img
+
+clean-images:
+	rm -rf /var/tmp/imageio-images/
+
+/var/tmp/imageio-images/cirros-0.3.5.img:
+	mkdir -p $(dir $@)
+	LIBGUESTFS_BACKEND=direct virt-builder cirros-0.3.5 \
+		--write /etc/cirros-init/config:DATASOURCE_LIST="nocloud" \
+		--root-password password: \
+		-o $@
 
 storage:
 	userstorage create storage.py

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -14,6 +14,5 @@ create_loop_devices() {
 
 create_loop_devices 16
 
-make
 make storage
 make check

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,10 +68,6 @@ Create storage for the tests:
 
 See "Creating storage for tests" for more info.
 
-Before running the tests, make the project:
-
-    make
-
 To run all the tests:
 
     make check
@@ -106,6 +102,21 @@ source, you can change these environment variables:
 
 When you run the tests, they will use QEMU and QEMU_NBD from the
 environment variables.
+
+
+## Running the daemon from source
+
+To run the ovirt-imageio daemon directly from source, you need to run
+make:
+
+    make
+
+This builds the C extension if needed. Then you can start the daemon:
+
+    ./ovirt-imageio -c test
+
+To daemon is configured to log using DEBUG log level to standard error.
+To stop the daemon press Control-C.
 
 
 ## Testing rpms

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,6 +92,18 @@ To list all test envs use:
     tox -l
 
 
+## The test images
+
+The test images are created automatically when running "make check". If
+you want to create them without running "make check", run:
+
+    make images
+
+To delete the test images run:
+
+    make clean-images
+
+
 ## Using local qemu builds
 
 Some tests run qemu-kvm or qemu-nbd. To run qemu or qemu-nbd built from

--- a/test/backup_test.py
+++ b/test/backup_test.py
@@ -16,8 +16,6 @@ from ovirt_imageio._internal import qemu_img
 from ovirt_imageio._internal import qemu_nbd
 
 from . import backup
-from . import ci
-from . import distro
 from . import qemu
 from . import qmp
 from . import testutil
@@ -71,15 +69,8 @@ def test_full_backup(tmpdir, fmt, transport):
             assert d.read(i, 512) == b.read(512)
 
 
-# This times out randomly on gitub with 120 seconds timoeut. In this example
-# the test took about 60 seconds (setup + call) but in other runs the tests
-# timed out after 120 seconds.
-#   44.29s setup    test/backup_test.py::test_full_backup_guest
-#   15.94s call     test/backup_test.py::test_full_backup_guest
-@pytest.mark.timeout(180)
-@pytest.mark.xfail(
-    ci.is_ovirt() or distro.is_centos("9"),
-    reason="Always times out", run=False)
+# Test can take 23 seconds on github.
+@pytest.mark.timeout(60)
 def test_full_backup_guest(tmpdir, base_image):
     base = qemu_img.info(base_image)
     disk_size = base["virtual-size"]
@@ -113,10 +104,8 @@ def test_full_backup_guest(tmpdir, base_image):
     verify_backup(backup_disk, ["before-backup"])
 
 
-@pytest.mark.timeout(180)
-@pytest.mark.xfail(
-    ci.is_ovirt() or distro.is_centos("9"),
-    reason="Always times out", run=False)
+# Test can take 20 seconds on github.
+@pytest.mark.timeout(60)
 def test_incremental_backup_guest(tmpdir, base_image):
     base = qemu_img.info(base_image)
     disk_size = base["virtual-size"]


### PR DESCRIPTION
- Fix the way we build the extension module in the Makefile
- Remove unneeded "make" call in the CI, and improve docs for running the tests
- Improve the way we create the base image for the backup tests so we can avoid long timeouts in the CI, and run the tests on all tested distros.
- Document how to create and delete the test images