### PR TITLE
copr: Install python3-setuptools

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -7,5 +7,6 @@
 
 srpm:
 	# Git is required to create release suffix.
-	dnf -y install git
+	# python3-setuptools required for building srpm.
+	dnf -y install git python3-setuptools
 	$(MAKE) srpm OUTDIR=$(outdir)


### PR DESCRIPTION
Switching to setuptools broke the copr Makefile, since
python3-setuptools is not installed in the Fedora mock environment
creating the source rpm.

Fixes: 4ab3229b55bc (tox: Fix tests with multiple python versions)
Signed-off-by: Nir Soffer <nsoffer@redhat.com>