### PR TITLE
Build and docs improvements

### DIFF
--- a/docker/Dockerfile.centos-8
+++ b/docker/Dockerfile.centos-8
@@ -17,9 +17,11 @@ RUN echo v1 \
         openssl \
         python3-devel \
         python3-pip \
+        python3-setuptools \
         python3-systemd \
         python38-devel \
         python38-pip \
+        python38-setuptools \
         qemu-img \
         qemu-kvm \
         rpm-build \

--- a/docker/Dockerfile.centos-9
+++ b/docker/Dockerfile.centos-9
@@ -15,6 +15,7 @@ RUN echo v1 \
         openssl \
         python3-devel \
         python3-pip \
+        python3-setuptools \
         python3-systemd \
         qemu-img \
         qemu-kvm \

--- a/docker/Dockerfile.fedora-34
+++ b/docker/Dockerfile.fedora-34
@@ -14,6 +14,7 @@ RUN echo v1 \
         openssl \
         python3-devel \
         python3-pip \
+        python3-setuptools \
         python3-systemd \
         qemu-img \
         qemu-kvm \

--- a/docker/Dockerfile.fedora-35
+++ b/docker/Dockerfile.fedora-35
@@ -14,6 +14,7 @@ RUN echo v1 \
         openssl \
         python3-devel \
         python3-pip \
+        python3-setuptools \
         python3-systemd \
         qemu-img \
         qemu-kvm \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -9,5 +9,5 @@ $(targets):
 
 push:
 	for name in $(targets); do \
-		podman push imageio-test-$$name ovirtorg/imageio-test-$$name; \
+		podman push imageio-test-$$name quay.io/ovirt/imageio-test-$$name; \
 	done

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,6 +34,7 @@ Install the runtime requirements:
         openssl \
         python3-devel \
         python3-pip \
+        python3-setuptools \
         python3-systemd \
         qemu-img \
         qemu-kvm \

--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -39,12 +39,11 @@ rm -rf $RPM_BUILD_ROOT
 %package common
 Summary:   oVirt imageio common resources
 
-# NOTE: keep in sync with automation/build-artifacts.packages
+# NOTE: keep in sync with docs/development.md
 BuildRequires: gcc
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 
-# NOTE: keep in sync with automation/check.packages
 Requires:  python3
 
 %description common
@@ -61,7 +60,6 @@ Common resources used by oVirt imageio server and client
 %package client
 Summary:   oVirt imageio client library
 
-# NOTE: keep in sync with automation/check.packages
 Requires:  %{name}-common = %{version}-%{release}
 
 %if 0%{?rhel}
@@ -83,12 +81,11 @@ Python client library for accessing imageio server on oVirt hosts.
 %package daemon
 Summary:   oVirt imageio daemon
 
-# NOTE: keep in sync with automation/build-artifacts.packages
+# NOTE: keep in sync with docs/development.md
 BuildRequires: systemd
 
-# NOTE: keep in sync with automation/check.packages
-Requires:  %{name}-common = %{version}-%{release}
 Requires:  python3-systemd
+Requires:  %{name}-common = %{version}-%{release}
 
 %description daemon
 Daemon providing image transfer service on oVirt hosts.

--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -42,6 +42,7 @@ Summary:   oVirt imageio common resources
 # NOTE: keep in sync with automation/build-artifacts.packages
 BuildRequires: gcc
 BuildRequires: python3-devel
+BuildRequires: python3-setuptools
 
 # NOTE: keep in sync with automation/check.packages
 Requires:  python3


### PR DESCRIPTION
- Fix Fedora copr builds, broken by recent change to use setuptools.
- Add python3-setuptools to the docker files to make the requirement explicit
- Update docs/developmemnt.md to include python3-steuptools to match the spec and docker files
- Update stale notes about automation packages files
- Fix docker Makefile so it pushes to quay.io