### PR TITLE
examples: Show how to use client.checksum()

### DIFF
--- a/examples/checksum
+++ b/examples/checksum
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+# ovirt-imageio
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""
+Show how to compute disk image checksum.
+"""
+import sys
+from ovirt_imageio import client
+
+path = sys.argv[1]
+res = client.checksum(path, algorithm="sha256")
+print(f"{res['checksum']}  {path}")


### PR DESCRIPTION
Add simple example showing how to use client.checksum() to compute a
checksum for local image.

This is mainly useful for benchmarking, for example comparing to
sha256sum, or blksum.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>