### PR TITLE
copr: Workaround for CVE-2022-24765 fix

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -9,4 +9,14 @@ srpm:
 	# Git is required to create release suffix.
 	# python3-setuptools required for building srpm.
 	dnf -y install git python3-setuptools
+
+	# Workaround for CVE-2022-24765 fix:
+	#
+	#	fatal: unsafe repository ('/path' is owned by someone else)
+	#
+	# Without this build-aux/release is confused, and all builds have same
+	# build from tag version (e.g. 2.4.4-1.fc35) instead a master build version
+	# (2.4.4-0.202204031154.git300480e.fc35).
+	git config --global --add safe.directory "$(shell pwd)"
+
 	$(MAKE) srpm OUTDIR=$(outdir)

--- a/ovirt_imageio/_internal/version.py
+++ b/ovirt_imageio/_internal/version.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-string = "2.4.4"
+string = "2.4.5"
 
 if __name__ == "__main__":
     print(string)


### PR DESCRIPTION
Copr runs "make srpm" in a directory not owned by the current user. This
breaks git commands and we get the wrong version number (e.g. 2.4.4-1)
instead of (2.4.4-0.timestamp.githash). The wrong version number break
users and OST, never getting the latest version.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>