### PR TITLE
config: Remove unused daemon:auth_timeout

### DIFF
--- a/data/README
+++ b/data/README
@@ -47,11 +47,6 @@
 # The default value:
 #   max_connections = 8
 
-# Number of seconds before unauthorized connections are
-# disconnected.
-# The default value:
-#   auth_timeout = 15
-
 # Number of seconds before inactive connections are disconnected.
 # Clients with special needs can request a larger timeout when
 # creating an image transfer.

--- a/ovirt_imageio/_internal/config.py
+++ b/ovirt_imageio/_internal/config.py
@@ -20,10 +20,6 @@ class daemon:
     # decrease throughput.
     max_connections = 8
 
-    # Number of seconds before unauthorized connections are
-    # disconnected.
-    auth_timeout = 15
-
     # Number of seconds before inactive connections are disconnected.
     # Clients with special needs can request a larger timeout when
     # creating an image transfer.


### PR DESCRIPTION
When we added configurable inactivity timeout, we added also auth
timeout but it was never used. The value was hardcoded to 15 seconds in
2.4.3 and was reverted back to 60 seconds in 2.4.5.

Fixes: d5e9c757e0a4 (http: Configurable inactivity timeout)
Signed-off-by: Nir Soffer <nsoffer@redhat.com>