### PR TITLE
imageio: add unit constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ htmlcov
 *.pyo
 *.so
 *.spec
+*.egg-info/
 */data/logger.conf
 MANIFEST
 build

--- a/ovirt_imageio/_internal/backends/file.py
+++ b/ovirt_imageio/_internal/backends/file.py
@@ -17,6 +17,7 @@ from .. import errors
 from .. import extent
 from .. import ioutil
 from .. import util
+from ..units import MiB
 
 from . common import CLOSED
 
@@ -504,7 +505,7 @@ class FileBackend(Backend):
         """
         Write zeros manually.
         """
-        buf_size = min(count, 1024**2)
+        buf_size = min(count, MiB)
         with util.aligned_buffer(buf_size) as buf, memoryview(buf) as view:
             while count:
                 count -= self.write(view[:count])

--- a/ovirt_imageio/_internal/backends/http.py
+++ b/ovirt_imageio/_internal/backends/http.py
@@ -19,6 +19,7 @@ import ssl
 from .. import errors
 from .. import extent
 from .. import http
+from ..units import KiB
 
 from . common import CLOSED
 
@@ -548,7 +549,7 @@ class Backend:
         """
         self._put_header(length)
 
-        buf = bytearray(128 * 1024)
+        buf = bytearray(128 * KiB)
         todo = length
         while todo > len(buf):
             self._con.send(buf)

--- a/ovirt_imageio/_internal/blkhash.py
+++ b/ovirt_imageio/_internal/blkhash.py
@@ -11,10 +11,11 @@ import os
 from functools import partial
 
 from . import ioutil
+from .units import MiB
 
 # These settings give best result for Fedora 32 image when using the nbd
 # backend. More testing is needed to determine if this is the best default.
-BLOCK_SIZE = 4 * 1024**2
+BLOCK_SIZE = 4 * MiB
 ALGORITHM = "blake2b"
 DIGEST_SIZE = 32
 

--- a/ovirt_imageio/_internal/config.py
+++ b/ovirt_imageio/_internal/config.py
@@ -7,6 +7,7 @@
 # (at your option) any later version.
 
 from . import configloader
+from .units import MiB
 
 
 class daemon:
@@ -84,7 +85,7 @@ class backend_file:
     # end storage, using iSCSI and FC. Larger values may increase throughput
     # slightly, but may also decrease it significantly.
     # TODO: Tested with single writer, needs testing with multiple readers.
-    buffer_size = 8 * 1024**2
+    buffer_size = 8 * MiB
 
 
 class backend_http:
@@ -100,7 +101,7 @@ class backend_http:
     # Buffer size in bytes for handling proxy requests. The default value was
     # copied form the file backend.
     # TODO: Needs testing with multiple readers and writers.
-    buffer_size = 8 * 1024**2
+    buffer_size = 8 * MiB
 
 
 class backend_nbd:
@@ -108,7 +109,7 @@ class backend_nbd:
     # Buffer size in bytes when reading and writing to the nbd backend. The
     # default value was copied form the file backend.
     # TODO: Needs testing with multiple readers and writers.
-    buffer_size = 8 * 1024**2
+    buffer_size = 8 * MiB
 
 
 class remote:

--- a/ovirt_imageio/_internal/directio.py
+++ b/ovirt_imageio/_internal/directio.py
@@ -21,6 +21,7 @@ from . import ops
 from . import stats
 from . import util
 from . backends import file
+from .units import MiB
 
 
 class Receive(ops.Write):
@@ -31,7 +32,7 @@ class Receive(ops.Write):
     """
 
     def __init__(self, path, src, size=None, offset=0, flush=True,
-                 buffersize=1024**2, clock=stats.NullClock()):
+                 buffersize=MiB, clock=stats.NullClock()):
         url = urllib_parse.urlparse("file:" + path)
         self._dst = file.open(url, "r+")
         buf = util.aligned_buffer(buffersize)

--- a/ovirt_imageio/_internal/io.py
+++ b/ovirt_imageio/_internal/io.py
@@ -18,17 +18,18 @@ from functools import partial
 
 from . import util
 from . backends import Wrapper
+from .units import MiB
 
 # Limit maximum zero and copy size to spread the workload better to multiple
 # workers and ensure frequent progress updates when handling large extents.
-MAX_ZERO_SIZE = 128 * 1024**2
-MAX_COPY_SIZE = 128 * 1024**2
+MAX_ZERO_SIZE = 128 * MiB
+MAX_COPY_SIZE = 128 * MiB
 
 # NBD hard limit.
-MAX_BUFFER_SIZE = 32 * 1024**2
+MAX_BUFFER_SIZE = 32 * MiB
 
 # TODO: Needs more testing.
-BUFFER_SIZE = 4 * 1024**2
+BUFFER_SIZE = 4 * MiB
 MAX_WORKERS = 4
 
 log = logging.getLogger("io")

--- a/ovirt_imageio/_internal/nbd.py
+++ b/ovirt_imageio/_internal/nbd.py
@@ -19,6 +19,7 @@ import struct
 
 from . import ipv6
 from . import sockutil
+from .units import MiB
 
 # Matcher for NBD Unix URL path.
 # nbd:unix:path[:exportname=name]
@@ -391,7 +392,7 @@ class Client:
 
         self.minimum_block_size = 1
         self.preferred_block_size = 4096
-        self.maximum_block_size = 32 * 1024**2
+        self.maximum_block_size = 32 * MiB
 
         # Set to "qemu:dirty-bitmap:bitmap-name" if dirty is True, server
         # supports structued replies, and exports a dirty bitmap. Use this name

--- a/ovirt_imageio/_internal/nbdutil.py
+++ b/ovirt_imageio/_internal/nbdutil.py
@@ -91,11 +91,12 @@ from collections import namedtuple
 
 from . import nbd
 from . import util
+from .units import MiB, GiB
 
 # NBD spec allows zeroing up to 2**32 - 1 bytes, buf some nbd servers like
 # qemu-nbd limit seems to be 2**31 - 512. Large zeros can delay more important
 # I/O so we like to zero is smaller steps.
-MAX_ZERO = 1024**3
+MAX_ZERO = GiB
 
 log = logging.getLogger("nbdutil")
 
@@ -118,7 +119,7 @@ def extents(client, offset=0, length=None, dirty=False):
 
     # NBD limit extents request to 4 GiB - 1. We use smaller step to limit the
     # number of extents kept in memory when accessing very fragmented images.
-    max_step = 2 * 1024**3
+    max_step = 2 * GiB
 
     # Keep the current extent, until we find a new extent with different flags.
     cur = None
@@ -204,7 +205,7 @@ def merged(extents_a, extents_b):
             a = None
 
 
-def copy(src_client, dst_client, block_size=4 * 1024**2, queue_depth=4,
+def copy(src_client, dst_client, block_size=4 * MiB, queue_depth=4,
          progress=None):
     """
     Copy export from src_client to dst_client.

--- a/ovirt_imageio/_internal/ops.py
+++ b/ovirt_imageio/_internal/ops.py
@@ -11,6 +11,7 @@ import logging
 from . import errors
 from . import stats
 from . import util
+from .units import MiB
 
 log = logging.getLogger("ops")
 
@@ -218,7 +219,7 @@ class Zero(Operation):
     # Limiting request size seems to avoid these timeouts. The disadvantage is
     # slower zeroing with file storage, but in this case the zeroing is
     # extremely fast so the difference is tiny.
-    MAX_STEP = 128 * 1024**2
+    MAX_STEP = 128 * MiB
 
     def __init__(self, dst, size, offset=0, flush=False, clock=None):
         super().__init__(size=size, offset=offset, clock=clock)

--- a/ovirt_imageio/_internal/units.py
+++ b/ovirt_imageio/_internal/units.py
@@ -1,0 +1,14 @@
+# ovirt-imageio
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+"""
+Constants for file/disk sizes.
+"""
+
+KiB = 1024
+MiB = 1024**2
+GiB = 1024**3

--- a/ovirt_imageio/_internal/util.py
+++ b/ovirt_imageio/_internal/util.py
@@ -12,6 +12,8 @@ import mmap
 import os
 import threading
 
+from .units import KiB
+
 
 def start_thread(func, args=(), kwargs=None, name=None, daemon=True):
     if kwargs is None:
@@ -28,9 +30,9 @@ def monotonic_time():
 
 def humansize(n):
     for unit in ("bytes", "KiB", "MiB", "GiB", "TiB", "PiB"):
-        if n < 1024:
+        if n < KiB:
             break
-        n /= 1024
+        n /= KiB
     return "{:.{precision}f} {}".format(
         n, unit, precision=0 if unit == "bytes" else 2)
 


### PR DESCRIPTION
There are many repetitions of `1024**2` and
`1024**3` for MiB and GiB, respectively.

Instead, add constants and use them
to make it more readable.

Fixes: #31
Signed-off-by: Albert Esteve <aesteve@redhat.com>