### PR TITLE
Always build ioutil for platform python

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,9 @@ deps =
     test: pytest-cov
     test: pytest-timeout
 commands_pre =
+    # Build ioutil for both current python (e.g. 3.8) and platform python (e.g. 3.6)
     python setup.py build_ext --build-lib .
+    /usr/bin/python3 setup.py build_ext --build-lib .
     python -c 'from test import testutil; print("ipv6 supported: %s" % testutil.ipv6_enabled())'
 commands =
     test: pytest -m 'not benchmark' --cov=ovirt_imageio --durations=10 {posargs}


### PR DESCRIPTION
When running py38 tests, we run ovirt-imageio using /usr/bin/python3,
but we built ioutil C extension with "python", which is python 3.8. We
cannot fix this by running the ovirt-imageio with python 3.8 since we
don't support python 3.8 for for the server.

Change tox to build the C extension for both current python version and
platform python.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>