### PR TITLE
admin_tool_test: add wait at srv fixture

### DIFF
--- a/test/admin_tool_test.py
+++ b/test/admin_tool_test.py
@@ -78,6 +78,7 @@ def srv(request, tmpdir_factory):
     finally:
         log.info("Terminating daemon")
         proc.terminate()
+        proc.wait()
 
 
 def test_ticket_life_cycle(srv):


### PR DESCRIPTION
In admin_tool_test, srv fixture is parametrized
to create two servers with built ovirt-imageio,
with a terminate at the end, between runs.

However, if runs do happen too fast
it may try to create the next server socket
before the previous is closed, resulting in
an "address already in use" error.

Add a wait() after terminate() to ensure we do
not run into such issue.

Signed-off-by: Albert Esteve <aesteve@redhat.com>