### PR TITLE
server_test: add wait after terminate

### DIFF
--- a/test/server_test.py
+++ b/test/server_test.py
@@ -231,6 +231,7 @@ def started_imageio(tmpdir, drop_privileges="true"):
         yield proc
     finally:
         proc.terminate()
+        proc.wait()
 
 
 def user_groups(user):


### PR DESCRIPTION
In server_test `started_imageio` fixture
creates servers with built ovirt-imageio,
and terminates the process at the end,
between runs.

However, if runs do happen too fast
it may try to create the next server socket
before the previous is closed, resulting in
an "address already in use" error.

Add a wait() after terminate() to ensure we do
not run into such issue.

Fixes: e6ed8210c19c98f3edb2ba8909bf83ca3571c57b
Signed-off-by: Albert Esteve <aesteve@redhat.com>