### PR TITLE
tests: avoid empty socket

### DIFF
--- a/test/admin_test.py
+++ b/test/admin_test.py
@@ -12,8 +12,6 @@ import uuid
 import pytest
 
 from ovirt_imageio import admin
-from ovirt_imageio._internal import config
-from ovirt_imageio._internal import server
 
 from . import testutil
 
@@ -21,10 +19,9 @@ log = logging.getLogger("test")
 
 
 @pytest.fixture(scope="module", params=["daemon", "proxy"])
-def srv(request):
+def srv(srv_factory, request):
     path = "test/conf/{}.conf".format(request.param)
-    cfg = config.load(path)
-    s = server.Server(cfg)
+    s = srv_factory(path)
     s.start()
     yield s
     s.stop()

--- a/test/admin_tool_test.py
+++ b/test/admin_tool_test.py
@@ -9,6 +9,7 @@ import json
 import logging
 import subprocess
 import time
+import uuid
 
 import pytest
 
@@ -31,7 +32,7 @@ ca_file = test/pki/system/ca.pem
 port = 0
 
 [local]
-socket =
+socket = {local_socket}
 
 [control]
 transport = {control_transport}
@@ -58,6 +59,7 @@ def srv(request, tmpdir_factory):
 
     conf = DAEMON_CONF.format(
         run_dir=str(tmp_dir),
+        local_socket=f"\0/org/ovirt/imageio/{uuid.uuid4()}",
         control_transport=request.param,
         control_port=random_port)
     conf_file.write(conf)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -16,13 +16,11 @@ import pytest
 
 from ovirt_imageio import client
 from ovirt_imageio._internal import blkhash
-from ovirt_imageio._internal import config
 from ovirt_imageio._internal import ipv6
 from ovirt_imageio._internal import nbd
 from ovirt_imageio._internal import nbdutil
 from ovirt_imageio._internal import qemu_img
 from ovirt_imageio._internal import qemu_nbd
-from ovirt_imageio._internal import server
 
 from ovirt_imageio._internal.extent import ZeroExtent, DirtyExtent
 
@@ -36,9 +34,8 @@ IMAGE_SIZE = 3 * CLUSTER_SIZE
 
 
 @pytest.fixture(scope="module")
-def srv():
-    cfg = config.load(["test/conf/daemon.conf"])
-    s = server.Server(cfg)
+def srv(srv_factory):
+    s = srv_factory("test/conf/daemon.conf")
     s.start()
     yield s
     s.stop()

--- a/test/conf/daemon.conf
+++ b/test/conf/daemon.conf
@@ -19,9 +19,6 @@ buffer_size = 131072
 [remote]
 port = 0
 
-[local]
-socket =
-
 [control]
 transport = unix
 socket = test/daemon.sock

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,14 +11,17 @@ import logging
 import os
 import subprocess
 import urllib.parse
+import uuid
 
 from collections import namedtuple
 
 import pytest
 
+from ovirt_imageio._internal import config
 from ovirt_imageio._internal import nbd
 from ovirt_imageio._internal import qemu_nbd
 from ovirt_imageio._internal import util
+from ovirt_imageio._internal import server
 
 log = logging.getLogger("test")
 
@@ -121,3 +124,13 @@ def fake_time(monkeypatch):
     time = FakeTime()
     monkeypatch.setattr(util, "monotonic_time", time.monotonic_time)
     return time
+
+
+@pytest.fixture(scope="module")
+def srv_factory():
+    def _factory(path):
+        cfg = config.load(path)
+        cfg.local.socket = f"\0/org/ovirt/imageio/{uuid.uuid4()}"
+        return server.Server(cfg)
+
+    return _factory

--- a/test/handlers/checksum_test.py
+++ b/test/handlers/checksum_test.py
@@ -14,10 +14,8 @@ import userstorage
 import pytest
 
 from ovirt_imageio._internal import blkhash
-from ovirt_imageio._internal import config
 from ovirt_imageio._internal import qemu_img
 from ovirt_imageio._internal import qemu_nbd
-from ovirt_imageio._internal import server
 
 from .. import testutil
 from .. import http
@@ -40,9 +38,8 @@ def user_file(request):
 
 
 @pytest.fixture(scope="module")
-def srv():
-    cfg = config.load(["test/conf/daemon.conf"])
-    s = server.Server(cfg)
+def srv(srv_factory):
+    s = srv_factory("test/conf/daemon.conf")
     s.start()
     yield s
     s.stop()

--- a/test/handlers/extents_test.py
+++ b/test/handlers/extents_test.py
@@ -13,9 +13,6 @@ import subprocess
 import userstorage
 import pytest
 
-from ovirt_imageio._internal import config
-from ovirt_imageio._internal import server
-
 from .. import testutil
 from .. import http
 from .. import storage
@@ -36,9 +33,8 @@ def user_file(request):
 
 
 @pytest.fixture(scope="module")
-def srv():
-    cfg = config.load(["test/conf/daemon.conf"])
-    s = server.Server(cfg)
+def srv(srv_factory):
+    s = srv_factory("test/conf/daemon.conf")
     s.start()
     yield s
     s.stop()

--- a/test/handlers/images_test.py
+++ b/test/handlers/images_test.py
@@ -13,9 +13,6 @@ import time
 
 import pytest
 
-from ovirt_imageio._internal import config
-from ovirt_imageio._internal import server
-
 from .. import testutil
 from .. import http
 
@@ -32,9 +29,8 @@ ALL_FEATURES = BASE_FEATURES | {"zero", "flush"}
 
 
 @pytest.fixture(scope="module")
-def srv():
-    cfg = config.load(["test/conf/daemon.conf"])
-    s = server.Server(cfg)
+def srv(srv_factory):
+    s = srv_factory("test/conf/daemon.conf")
     s.start()
     yield s
     s.stop()

--- a/test/local_test.py
+++ b/test/local_test.py
@@ -14,17 +14,13 @@ import stat
 
 import pytest
 
-from ovirt_imageio._internal import config
-from ovirt_imageio._internal import server
-
 from . import http
 from . import testutil
 
 
 @pytest.fixture(scope="module")
-def srv():
-    cfg = config.load(["test/conf/daemon.conf"])
-    s = server.Server(cfg)
+def srv(srv_factory):
+    s = srv_factory("test/conf/daemon.conf")
     s.start()
     try:
         yield s

--- a/test/proxy_test.py
+++ b/test/proxy_test.py
@@ -17,16 +17,16 @@ from . import testutil
 
 
 @pytest.fixture(scope="module")
-def daemon():
-    daemon = server.Server(config.load(["test/conf/daemon.conf"]))
+def daemon(srv_factory):
+    daemon = srv_factory("test/conf/daemon.conf")
     daemon.start()
     yield daemon
     daemon.stop()
 
 
 @pytest.fixture(scope="module")
-def proxy():
-    proxy = server.Server(config.load(["test/conf/proxy.conf"]))
+def proxy(srv_factory):
+    proxy = srv_factory("test/conf/proxy.conf")
     proxy.start()
     yield proxy
     proxy.stop()

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -10,6 +10,7 @@ import json
 import os
 import pwd
 import subprocess
+import uuid
 
 import pytest
 
@@ -39,7 +40,7 @@ ca_file = test/pki/system/ca.pem
 port = 0
 
 [local]
-socket =
+socket = {local_socket}
 
 [control]
 transport = unix
@@ -202,6 +203,7 @@ def prepare_config(tmpdir, drop_privileges="true"):
         drop_priv=drop_privileges,
         user_name="nobody",
         group_name="nobody",
+        local_socket=f"\0/org/ovirt/imageio/{uuid.uuid4()}",
     )
     tmpdir.join("conf", "conf.d", "daemon.conf").write(daemon_conf)
 


### PR DESCRIPTION
A recent change in cpython broke autobind of abstract
unix socket in linux, causing bind calls with an
empty string to be bound to '\0' instead of a
random address (expected). This results in an
'address already in use' error when consecutive empty
string binding is used in the tests.

While this issue may get solved eventually, we
can change the test strategy and use the random
unique addresses in the abstract space, to create
unique sockets per test so that they do not collide,
and do not depend on the empty socket feature.

Related: https://github.com/python/cpython/issues/94821
Signed-off-by: Albert Esteve <aesteve@redhat.com>