### PR TITLE
uhttp: force empty string to random addr

### DIFF
--- a/ovirt_imageio/_internal/uhttp.py
+++ b/ovirt_imageio/_internal/uhttp.py
@@ -11,6 +11,7 @@ import http.client as http_client
 import logging
 import os
 import socket
+import uuid
 
 from . import http
 from . import util
@@ -61,7 +62,13 @@ class Server(http.Server):
 
         if self.server_address == "":
             # User wants to bind to a random abstract socket.
-            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_PASSCRED, 1)
+            # A recent change in cpython broke autobind of abstract
+            # unix socket in linux, causing bind calls with an
+            # empty string to be bound to '\0' instead of a
+            # random address.
+            # Until it is fixed, we need to generate random address ourselves.
+            # See https://github.com/python/cpython/issues/94821
+            self.server_address = f"\0{uuid.uuid4()}"
 
     def server_bind(self):
         """


### PR DESCRIPTION
A recent change in cpython broke autobind of abstract
unix socket in linux, causing bind calls with an
empty string to be bound to '\0' instead of a
random address (expected). This results in an
'address already in use' error when consecutive empty
string binding is used.

While we wait for this issue to be solved, we need
to enforce a random address to be used for empty
strings in the abstract space.

Related: python/cpython#94821
Signed-off-by: Albert Esteve <aesteve@redhat.com>