### PR TITLE
ci: split centos 8 jobs for py36 and py38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro:
-        - centos-8
-        - centos-9
-        - fedora-35
-        - fedora-36
+        include:
+          - distro: centos-8
+            env: py36
+          - distro: centos-8
+            env: py38
+          - distro: centos-9
+            env: py39
+          - distro: fedora-35
+            env: py310
+          - distro: fedora-36
+            env: py310
     container:
       image: quay.io/ovirt/imageio-test-${{matrix.distro}}
       # Required to create loop devices.
@@ -22,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
-      run: ci/test.sh
+      run: ci/test.sh ${{matrix.env}}
   rpm:
     runs-on: ubuntu-latest
     strategy:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -21,5 +21,13 @@ git config --global --add safe.directory "$(pwd)"
 # Enable IPv6
 echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6
 
+if [ -z $1 ]; then
+    echo "Missing argument 'ENV' (tox environment)."
+    echo "Usage: $0 ENV"
+    exit 1
+fi
+
+env="$1"
+
 make storage
-make check
+tox -e flake8,test-$env,bench-$env


### PR DESCRIPTION
On centos 8 we run the tests twice both with python 3.6
(platform python) and python 3.8. This doubles the
run time and makes it harder to check failures.
Other distros only run a single python environment
tests, but checks for all of them, creating a lot
of unnecesary noise in the logs.

Separate centos-8 enviornments for py36 and py38
to allow parallel execution. Other distributions
should run only a specific python environment
that matches the one they have installed.

Fixes: https://github.com/oVirt/ovirt-imageio/issues/90
Signed-off-by: Albert Esteve <aesteve@redhat.com>