### PR TITLE
client: Less noisy progress

### DIFF
--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -35,59 +35,55 @@ def test_draw():
     f = FakeFile()
 
     # Size is unknown at this point.
-    pb = client.ProgressBar(output=f, step=0.1, now=fake_time)
+    pb = client.ProgressBar(output=f, now=fake_time)
     assert f.last == (
-        "[ ------- ] 0 bytes, 0.00 seconds, 0 bytes/s".ljust(79) + "\r"
+        "[ ---- ] 0 bytes, 0.00 seconds, 0 bytes/s".ljust(79) + "\r"
     )
 
-    # Size was updated.
+    # Size was updated, but no bytes were transfered yet.
     fake_time.now += 0.1
     pb.size = 3 * 1024**3
     pb.update(0)
     assert f.last == (
-        "[   0.00% ] 0 bytes, 0.10 seconds, 0 bytes/s".ljust(79) + "\r"
+        "[   0% ] 0 bytes, 0.10 seconds, 0 bytes/s".ljust(79) + "\r"
     )
 
     # Write some data...
     fake_time.now += 1.0
     pb.update(512 * 1024**2)
     assert f.last == (
-        "[  16.67% ] 512.00 MiB, 1.10 seconds, 465.45 MiB/s".ljust(79) + "\r"
+        "[  16% ] 512.00 MiB, 1.10 seconds, 465.45 MiB/s".ljust(79) + "\r"
     )
 
-    # Write zeros, much faster, but it is not time to update yet...
-    fake_time.now += 0.05
-    pb.update(512 * 1024**2)
+    # Write zeros (much faster)...
+    fake_time.now += 0.2
+    pb.update(2 * 1024**3)
     assert f.last == (
-        "[  16.67% ] 512.00 MiB, 1.10 seconds, 465.45 MiB/s".ljust(79) + "\r"
-    )
-
-    # Write more zeors, time to update...
-    fake_time.now += 0.05
-    pb.update(512 * 1024**2)
-    assert f.last == (
-        "[  50.00% ] 1.50 GiB, 1.20 seconds, 1.25 GiB/s".ljust(79) + "\r"
-    )
-
-    # More zeros, rates increases...
-    fake_time.now += 0.1
-    pb.update(1024**3)
-    assert f.last == (
-        "[  83.33% ] 2.50 GiB, 1.30 seconds, 1.92 GiB/s".ljust(79) + "\r"
+        "[  83% ] 2.50 GiB, 1.30 seconds, 1.92 GiB/s".ljust(79) + "\r"
     )
 
     # More data, slow down again...
     fake_time.now += 1.0
     pb.update(512 * 1024**2)
     assert f.last == (
-        "[ 100.00% ] 3.00 GiB, 2.30 seconds, 1.30 GiB/s".ljust(79) + "\r"
+        "[ 100% ] 3.00 GiB, 2.30 seconds, 1.30 GiB/s".ljust(79) + "\r"
     )
 
     # Flush takes some time, lowering final rate.
     fake_time.now += 0.1
     pb.close()
     assert f.last == (
-        "[ 100.00% ] 3.00 GiB, 2.40 seconds, 1.25 GiB/s".ljust(79) + "\n"
+        "[ 100% ] 3.00 GiB, 2.40 seconds, 1.25 GiB/s".ljust(79) + "\n"
+    )
+
+
+def test_with_size():
+    fake_time = FakeTime()
+    f = FakeFile()
+
+    client.ProgressBar(size=3 * 1024**3, output=f, now=fake_time)
+    assert f.last == (
+        "[   0% ] 0 bytes, 0.00 seconds, 0 bytes/s".ljust(79) + "\r"
     )
 
 


### PR DESCRIPTION
Previously we updated the progress up to 10 times per second, and we
displayed fractional percent values (e.g. 12.57%). This is too noisy and
creates too many uninteresting updates. It also calls
time.monotonic_time() on every update to check if it is time to update
which is waste of resources for very little benefit.

Change the progress to show integer values (12%) and update the progress
only when the progress value changes. With this change we update the
progress up to 100 times during a transfer.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>