### PR TITLE
Progress bar cleanups

### DIFF
--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -66,9 +66,7 @@ class ProgressBar:
 
     def close(self):
         with self._lock:
-            # If we wrote progress, we need to draw the last progress line.
-            if self._done > 0:
-                self._draw(last=True)
+            self._draw(last=True)
 
     def _draw(self, last=False):
         elapsed = self._now() - self._start

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -39,6 +39,7 @@ class ProgressBar:
         self._done = 0
         # Value in percent. We start with -1 so the first update will show 0%.
         self._value = -1
+        self._closed = False
 
         # The first update can take some time.
         self._draw()
@@ -57,6 +58,8 @@ class ProgressBar:
         [1] https://github.com/tqdm/tqdm#manual
         """
         with self._lock:
+            if self._closed:
+                return
             self._done += n
             if self.size:
                 new_value = int(self._done / self.size * 100)
@@ -66,7 +69,9 @@ class ProgressBar:
 
     def close(self):
         with self._lock:
-            self._draw(last=True)
+            if not self._closed:
+                self._closed = True
+                self._draw(last=True)
 
     def _draw(self, last=False):
         elapsed = self._now() - self._start

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -75,19 +75,11 @@ class ProgressBar:
 
     def _draw(self, last=False):
         elapsed = self._now() - self._start
+        progress = f"{max(0, self._value):3d}%" if self.size else "----"
+        done = util.humansize(self._done)
+        rate = util.humansize(self._done / elapsed if elapsed else 0)
 
-        if self.size:
-            progress = "%3d%%" % max(0, self._value)
-        else:
-            progress = "----"
-
-        line = "[ %s ] %s, %.2f seconds, %s/s" % (
-            progress,
-            util.humansize(self._done),
-            elapsed,
-            util.humansize(self._done / elapsed if elapsed else 0),
-        )
-
+        line = f"[ {progress} ] {done}, {elapsed:.2f} seconds, {rate}/s"
         line = line.ljust(self._width, " ")
 
         # Using "\r" moves the cursor to the first column, so the next progress

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -18,7 +18,7 @@ class ProgressBar:
     def __init__(self, size=0, output=sys.stdout, step=None, width=79,
                  now=time.monotonic):
         """
-        Argumnets:
+        Arguments:
             size (int): total number of bytes. If size is unknown when
                 creating, progress value is not displayed. The size can be set
                 later to enable progress display.
@@ -88,7 +88,7 @@ class ProgressBar:
         line = line.ljust(self.width, " ")
 
         # Using "\r" moves the cursor to the first column, so the next progress
-        # will overwite this one. If this is the last progress, we use "\n" to
+        # will overwrite this one. If this is the last progress, we use "\n" to
         # move to the next line. Otherwise, the next shell prompt will include
         # part of the old progress.
         end = "\n" if last else "\r"

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -77,7 +77,7 @@ class ProgressBar:
         elapsed = self._now() - self._start
         progress = f"{max(0, self._value):3d}%" if self.size else "----"
         done = util.humansize(self._done)
-        rate = util.humansize(self._done / elapsed if elapsed else 0)
+        rate = util.humansize((self._done / elapsed) if elapsed else 0)
 
         line = f"[ {progress} ] {done}, {elapsed:.2f} seconds, {rate}/s"
         line = line.ljust(self._width, " ")

--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -87,6 +87,23 @@ def test_with_size():
     )
 
 
+def test_close():
+    f = FakeFile()
+    pb = client.ProgressBar(output=f)
+    pb.size = 1 * 1024**3
+    pb.update(512 * 1024**2)
+    pb.close()
+
+    # Once closed, update does not redraw.
+    f.last = None
+    pb.update(512 * 1024**2)
+    assert f.last is None
+
+    # Closing twice does not redraw.
+    pb.close()
+    assert f.last is None
+
+
 def test_contextmanager():
     f = FakeFile()
     with client.ProgressBar(1024**3, output=f) as pb:

--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -7,6 +7,7 @@
 # (at your option) any later version.
 
 from ovirt_imageio import client
+from ovirt_imageio._internal.units import MiB, GiB
 
 
 class FakeTime:
@@ -42,7 +43,7 @@ def test_draw():
 
     # Size was updated, but no bytes were transfered yet.
     fake_time.now += 0.1
-    pb.size = 3 * 1024**3
+    pb.size = 3 * GiB
     pb.update(0)
     assert f.last == (
         "[   0% ] 0 bytes, 0.10 seconds, 0 bytes/s".ljust(79) + "\r"
@@ -50,21 +51,21 @@ def test_draw():
 
     # Write some data...
     fake_time.now += 1.0
-    pb.update(512 * 1024**2)
+    pb.update(512 * MiB)
     assert f.last == (
         "[  16% ] 512.00 MiB, 1.10 seconds, 465.45 MiB/s".ljust(79) + "\r"
     )
 
     # Write zeros (much faster)...
     fake_time.now += 0.2
-    pb.update(2 * 1024**3)
+    pb.update(2 * GiB)
     assert f.last == (
         "[  83% ] 2.50 GiB, 1.30 seconds, 1.92 GiB/s".ljust(79) + "\r"
     )
 
     # More data, slow down again...
     fake_time.now += 1.0
-    pb.update(512 * 1024**2)
+    pb.update(512 * MiB)
     assert f.last == (
         "[ 100% ] 3.00 GiB, 2.30 seconds, 1.30 GiB/s".ljust(79) + "\r"
     )
@@ -81,7 +82,7 @@ def test_with_size():
     fake_time = FakeTime()
     f = FakeFile()
 
-    client.ProgressBar(size=3 * 1024**3, output=f, now=fake_time)
+    client.ProgressBar(size=3 * GiB, output=f, now=fake_time)
     assert f.last == (
         "[   0% ] 0 bytes, 0.00 seconds, 0 bytes/s".ljust(79) + "\r"
     )
@@ -90,13 +91,13 @@ def test_with_size():
 def test_close():
     f = FakeFile()
     pb = client.ProgressBar(output=f)
-    pb.size = 1 * 1024**3
-    pb.update(512 * 1024**2)
+    pb.size = 1 * GiB
+    pb.update(512 * MiB)
     pb.close()
 
     # Once closed, update does not redraw.
     f.last = None
-    pb.update(512 * 1024**2)
+    pb.update(512 * MiB)
     assert f.last is None
 
     # Closing twice does not redraw.
@@ -106,8 +107,8 @@ def test_close():
 
 def test_contextmanager():
     f = FakeFile()
-    with client.ProgressBar(1024**3, output=f) as pb:
-        pb.update(1024**3)
+    with client.ProgressBar(GiB, output=f) as pb:
+        pb.update(GiB)
         assert f.last.endswith("\r")
 
     assert f.last.endswith("\n")


### PR DESCRIPTION
- Spelling
- Make private attributes private
- Remove wrong check
- Ensure closed progress is not updated
- Modernize ProgressBar._draw
- Make conditional expression more clear
- Use unit constants in ui tests

Rebased on top of #102.