### PR TITLE
ovirt-img: Add logging options

### DIFF
--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -20,6 +20,29 @@ import os
 import sys
 
 
+class Choices:
+
+    def __init__(self, name, values):
+        self.name = name
+        self.values = values
+
+    def __call__(self, s):
+        if s not in self.values:
+            raise ValueError(
+                f"Invalid '{self.name}' value: '{s}', choices: {self}")
+        return s
+
+    def __str__(self):
+        s = ", ".join(self.values)
+        return f"{{{s}}}"
+
+    def __repr__(self):
+        return repr(self.name)
+
+
+log_level = Choices("log_level", ("debug", "info", "warning", "error"))
+
+
 class Option(
         namedtuple("Option", "name,args,config,required,type,default,help")):
 
@@ -88,6 +111,21 @@ class Parser:
             config=True,
             help=("Path to ovirt-engine CA certificate. If not set, read "
                   "from the specified config section"),
+        ),
+        Option(
+            name="log_file",
+            args=["--log-file"],
+            config=True,
+            default="/dev/stderr",
+            help="Log file name (default: /dev/stderr).",
+        ),
+        Option(
+            name="log_level",
+            args=["--log-level"],
+            config=True,
+            type=log_level,
+            default="warning",
+            help=(f"Log level (choices: {log_level}, default: warning)."),
         ),
     ]
 

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -15,6 +15,7 @@ from .. _internal.units import KiB, MiB, GiB, TiB
 import argparse
 import configparser
 import os
+import sys
 
 
 class Parser:
@@ -22,9 +23,8 @@ class Parser:
     def __init__(self):
         self._parser = argparse.ArgumentParser(
             description="Transfer disk images")
-        self._parser.set_defaults(
-            command=lambda _: self._parser.print_help(),
-            password=None)
+        # XXX password should not be here.
+        self._parser.set_defaults(command=None, password=None)
         self._commands = self._parser.add_subparsers(title="commands")
 
     def add_sub_command(self, name, help, func):
@@ -60,6 +60,10 @@ class Parser:
 
     def parse(self, args=None):
         args = self._parser.parse_args(args=args)
+        if not args.command:
+            self._parser.print_help()
+            sys.exit(2)
+
         if args.config:
             self._merge_config(args)
 

--- a/ovirt_imageio/client/_ovirt.py
+++ b/ovirt_imageio/client/_ovirt.py
@@ -54,7 +54,9 @@ def connect(args):
         url=f"{args.engine_url}/ovirt-engine/api",
         username=args.username,
         password=password,
-        ca_file=args.cafile)
+        ca_file=args.cafile,
+        log=log if args.log_file else None,
+        debug=args.log_level == "debug")
 
 
 def find_disk(con, disk_id):

--- a/ovirt_imageio/client/_tool.py
+++ b/ovirt_imageio/client/_tool.py
@@ -10,6 +10,8 @@
 Tool for transferring disk images.
 """
 
+import logging
+
 from . import _options
 from . import _download
 
@@ -19,7 +21,12 @@ def main():
     _download.register(parser)
     args = parser.parse()
 
-    # XXX Configure logging.
+    logging.basicConfig(
+        filename=args.log_file,
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)-7s (%(threadName)s) [%(name)s] "
+               "%(message)s")
+
     # XXX Setup signal handlers.
     # XXX Handle commands errors.
 

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -126,7 +126,7 @@ username = username
 
 def test_config_all(config):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
     args = parser.parse(["test", "-c", "all"])
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
@@ -139,7 +139,7 @@ def test_config_all(config):
 
 def test_config_all_override(config):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
     args = parser.parse([
         "test",
         "-c", "all",
@@ -159,7 +159,7 @@ def test_config_all_override(config):
 
 def test_config_required(config):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
     args = parser.parse(["test", "-c", "required"])
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
@@ -172,7 +172,7 @@ def test_config_required(config):
 
 def test_config_required_override(config):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
     args = parser.parse([
         "test",
         "-c", "required",
@@ -194,7 +194,7 @@ def test_config_required_override(config):
 ])
 def test_config_missing(config, capsys, name, missing):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
     with pytest.raises(SystemExit):
         parser.parse(["test", "-c", name])
     captured = capsys.readouterr()
@@ -203,7 +203,7 @@ def test_config_missing(config, capsys, name, missing):
 
 def test_config_missing_override(config):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
     args = parser.parse([
         "test",
         "-c", "missing3",
@@ -216,7 +216,7 @@ def test_config_missing_override(config):
 
 def test_config_no_section(config, capsys):
     parser = _options.Parser()
-    parser.add_sub_command("test", "help", None)
+    parser.add_sub_command("test", "help", lambda x: None)
 
     # Required paremeters are available via the command line, but the specified
     # configuration does not exist. This is likely a user error so fail loudly.

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -189,8 +189,9 @@ def test_config_required_override(config):
 
 
 @pytest.mark.parametrize("name,missing", [
-    ("missing1", "username"),
-    ("missing2", "engine_url"),
+    ("missing1", ["username"]),
+    ("missing2", ["engine_url"]),
+    ("missing3", ["engine_url", "username"]),
 ])
 def test_config_missing(config, capsys, name, missing):
     parser = _options.Parser()
@@ -198,7 +199,8 @@ def test_config_missing(config, capsys, name, missing):
     with pytest.raises(SystemExit):
         parser.parse(["test", "-c", name])
     captured = capsys.readouterr()
-    assert repr(missing) in captured.err
+    for name in missing:
+        assert name in captured.err
 
 
 def test_config_missing_override(config):


### PR DESCRIPTION
More general options parsing allowing mixing of command line
arguments and config options. Add log file options using the
new infrastructure.

This is part of #72