### PR TITLE
ovirt-img: Package as part of ovirt-imageio-client

### DIFF
--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -93,6 +93,7 @@ Requires:  %{name}-common = %{version}-%{release}
 # RHEL 8.4 version. Some features require qemu-nbd 5.2.0 and are disabled when
 # using older qemu-nbd.
 Requires:  qemu-img >= 15:4.2.0
+Requires:  python3-ovirt-engine-sdk4
 %else
 # Fedora.
 Requires:  qemu-img
@@ -103,6 +104,7 @@ Python client library for accessing imageio server on oVirt hosts.
 
 %files client
 %{python3_sitearch}/%{srcname}/client
+%{_bindir}/ovirt-img
 
 
 %package daemon

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "ovirt_imageio.admin",
     ],
     platforms=["Linux"],
-    scripts=["ovirt-imageio", "ovirt-imageioctl"],
+    scripts=["ovirt-imageio", "ovirt-imageioctl", "ovirt-img"],
     url="https://github.com/oVirt/ovirt-imageio",
     project_urls={
         "Documentation":


### PR DESCRIPTION
The ovirt-imageio-client package installs now the ovirt-img tool, and
requires python3-ovirt-engine-sdk4.

This is part of #72