### PR TITLE
ovirt-img: Terminate cleanly on signals

### DIFF
--- a/ovirt_imageio/_internal/io.py
+++ b/ovirt_imageio/_internal/io.py
@@ -251,7 +251,7 @@ class Worker:
         except Exception as e:
             self._errors.append(e)
             self._queue.close()
-            log.exception("Worker %s failed", self._name)
+            log.debug("Worker %s failed: %s", self._name, e)
         else:
             log.debug("Worker %s finished", self._name)
 

--- a/ovirt_imageio/client/_api.py
+++ b/ovirt_imageio/client/_api.py
@@ -20,16 +20,17 @@ from contextlib import contextmanager
 from urllib.parse import urlparse
 
 from .. _internal import blkhash
-from .. _internal import io
 from .. _internal import qemu_img
 from .. _internal import qemu_nbd
 from .. _internal.backends import http, nbd
 from .. _internal.handlers import checksum as _checksum
 from .. _internal.nbd import UnixAddress
 
+from . import _io
+
 # API constants.
-BUFFER_SIZE = io.BUFFER_SIZE
-MAX_WORKERS = io.MAX_WORKERS
+BUFFER_SIZE = _io.BUFFER_SIZE
+MAX_WORKERS = _io.MAX_WORKERS
 
 log = logging.getLogger("client")
 
@@ -95,7 +96,7 @@ def upload(filename, url, cafile, buffer_size=BUFFER_SIZE, secure=True,
                 backing_chain=backing_chain) as src:
 
             # Upload the image to the server.
-            io.copy(
+            _io.copy(
                 src,
                 dst,
                 max_workers=max_workers,
@@ -173,7 +174,7 @@ def download(url, filename, cafile, fmt="qcow2", incremental=False,
         with _open_nbd(filename, fmt, shared=max_workers) as dst:
 
             # Download the image from the server to the local image.
-            io.copy(
+            _io.copy(
                 src,
                 dst,
                 dirty=incremental,

--- a/ovirt_imageio/client/_io.py
+++ b/ovirt_imageio/client/_io.py
@@ -16,9 +16,9 @@ from collections import deque, namedtuple
 from contextlib import closing
 from functools import partial
 
-from . import util
-from . backends import Wrapper
-from .units import MiB
+from .. _internal import util
+from .. _internal.backends import Wrapper
+from .. _internal.units import MiB
 
 # Limit maximum zero and copy size to spread the workload better to multiple
 # workers and ensure frequent progress updates when handling large extents.

--- a/ovirt_imageio/client/_tool.py
+++ b/ovirt_imageio/client/_tool.py
@@ -11,9 +11,16 @@ Tool for transferring disk images.
 """
 
 import logging
+import os
+import signal
+import sys
 
 from . import _options
 from . import _download
+
+log = logging.getLogger("tool")
+
+terminated = None
 
 
 def main():
@@ -27,7 +34,23 @@ def main():
         format="%(asctime)s %(levelname)-7s (%(threadName)s) [%(name)s] "
                "%(message)s")
 
-    # XXX Setup signal handlers.
-    # XXX Handle commands errors.
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
 
-    args.command(args)
+    try:
+        args.command(args)
+    except Exception:
+        if terminated:
+            log.error("Terminated by signal %d", terminated)
+            sys.exit(128 + terminated)
+        else:
+            log.exception("Command failed")
+            sys.exit(1)
+
+
+def _handle_signal(signo, frame):
+    global terminated
+    if not terminated:
+        terminated = signo
+        # Terminate qemu-nbd triggering normal cleanup flow.
+        os.killpg(0, signo)


### PR DESCRIPTION
Handle SIGINT and SIGTERM by terminating qemu-nbd and triggering normal cleanup flow, removing the temporary directory and finalizing the image transfer.

When qemu-nbd is terminated, the worker threads may log noisy and unhelpful tracebacks. Since we already re-raise the first worker error, we can suppress these tracebacks.

When the tool is terminated by signal, we suppress errors from the tool (e.g. BrokenPipe). Otherwise we log one traceback on errors.

Here are some examples:

Terminated by SIGINT:
```
$ ./ovirt-img download-disk -c engine 07b53997-7b4c-4861-bf38-f6fbb29921d9 dl.qcow2
^C[   5% ] 2.50 GiB, 3.66 seconds, 698.52 MiB/s                                  
2022-07-27 14:29:58,892 ERROR   (MainThread) [tool] Terminated by signal 2
```

qemu-nbd killed during transfer:
```
$ ./ovirt-img download-disk -c engine 07b53997-7b4c-4861-bf38-f6fbb29921d9 dl.qcow2
[  13% ] 6.75 GiB, 8.88 seconds, 778.06 MiB/s                                  
2022-07-27 14:30:53,638 ERROR   (MainThread) [tool] Command failed
Traceback (most recent call last):
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/client/_tool.py", line 41, in main
    args.command(args)
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/client/_download.py", line 72, in download_disk
    _api.download(
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/client/_api.py", line 176, in download
    io.copy(
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/io.py", line 44, in copy
    with Executor(name=name) as executor:
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/io.py", line 196, in __exit__
    self.stop()
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/io.py", line 173, in stop
    raise self._errors[0]
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/io.py", line 245, in _run
    handler.copy(req)
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/io.py", line 289, in copy
    self._src.write_to(self._dst, req.length, self._buf)
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/backends/http.py", line 220, in write_to
    writer.write(view[:n])
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/backends/nbd.py", line 119, in write
    self._client.write(self._position, buf)
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/nbd.py", line 444, in write
    self._send(data)
  File "/home/nsoffer/src/ovirt-imageio/ovirt_imageio/_internal/nbd.py", line 1227, in _send
    self._sock.sendall(data)
BrokenPipeError: [Errno 32] Broken pipe
```
