### PR TITLE
ovirt-img: add upload-disk

### DIFF
--- a/ovirt_imageio/client/_download.py
+++ b/ovirt_imageio/client/_download.py
@@ -51,6 +51,7 @@ def register(parser):
 
     cmd.add_argument(
         "disk_id",
+        type=_options.UUID,
         help="Disk ID to download.")
 
     cmd.add_argument(

--- a/ovirt_imageio/client/_download.py
+++ b/ovirt_imageio/client/_download.py
@@ -12,8 +12,6 @@ Download commands.
 
 from contextlib import closing
 
-from .. _internal.units import KiB, MiB
-
 from . import _api
 from . import _options
 from . import _ovirt
@@ -31,23 +29,6 @@ def register(parser):
         choices=("raw", "qcow2"),
         default="qcow2",
         help="Download image format (default qcow2).")
-
-    size = _options.Size(minimum=1, default=_api.MAX_WORKERS, maximum=8)
-    cmd.add_argument(
-        "--max-workers",
-        type=size,
-        default=size.default,
-        help=f"Maximum number of workers (range: {size.minimum}-"
-             f"{size.maximum}, default: {size.default}).")
-
-    size = _options.Size(
-        minimum=64 * KiB, default=_api.BUFFER_SIZE, maximum=16 * MiB)
-    cmd.add_argument(
-        "--buffer-size",
-        type=size,
-        default=size.default,
-        help=f"Buffer size per worker (range: {size.minimum}-"
-             f"{size.maximum}, default: {size.default}).")
 
     cmd.add_argument(
         "disk_id",

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -14,6 +14,7 @@ import getpass
 from collections import namedtuple
 
 from .. _internal.units import KiB, MiB, GiB, TiB
+from . _api import MAX_WORKERS, BUFFER_SIZE
 
 import argparse
 import configparser
@@ -136,7 +137,7 @@ class Parser:
         self._parser.set_defaults(command=None)
         self._commands = self._parser.add_subparsers(title="commands")
 
-    def add_sub_command(self, name, help, func):
+    def add_sub_command(self, name, help, func, transfer_options=True):
         cmd = self._commands.add_parser(name, help=help)
         cmd.set_defaults(command=func)
 
@@ -150,6 +151,24 @@ class Parser:
                 dest=option.name,
                 type=option.type,
                 help=option.help)
+
+        if transfer_options:
+            size = Size(minimum=1, default=MAX_WORKERS, maximum=8)
+            cmd.add_argument(
+                "--max-workers",
+                type=size,
+                default=size.default,
+                help=f"Maximum number of workers (range: {size.minimum}-"
+                f"{size.maximum}, default: {size.default}).")
+
+            size = Size(
+                minimum=64 * KiB, default=BUFFER_SIZE, maximum=16 * MiB)
+            cmd.add_argument(
+                "--buffer-size",
+                type=size,
+                default=size.default,
+                help=f"Buffer size per worker (range: {size.minimum}-"
+                f"{size.maximum}, default: {size.default}).")
 
         return cmd
 

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -19,6 +19,7 @@ import argparse
 import configparser
 import os
 import sys
+import uuid
 
 
 class Choices:
@@ -280,3 +281,30 @@ class Size:
             raise ValueError(f"Size {s!r} > {self.maximum}")
 
         return value
+
+
+class Type:
+    """
+    Wrapper to expose function validators as types.
+    """
+
+    def __init__(self, name, func):
+        self.name = name
+        self.func = func
+
+    def __call__(self, value):
+        try:
+            return self.func(value)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid '{self.name}' value: '{value}': {e}") from e
+
+    def __repr__(self):
+        return self.name
+
+
+def _validate_uuid(id):
+    return str(uuid.UUID(id))
+
+
+UUID = Type("UUID", _validate_uuid)

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -326,4 +326,22 @@ def _validate_uuid(id):
     return str(uuid.UUID(id))
 
 
+def _validate_file(filename):
+    """
+    Validate that the file exists.
+
+    Raises:
+        ValueError
+
+    Returns:
+        str: filename
+    """
+    if not os.path.exists(filename):
+        raise ValueError(f"{filename} does not exist")
+    if not os.path.isfile(filename):
+        raise ValueError(f"{filename} is not a file")
+    return filename
+
+
 UUID = Type("UUID", _validate_uuid)
+File = Type("File", _validate_file)

--- a/ovirt_imageio/client/_ovirt.py
+++ b/ovirt_imageio/client/_ovirt.py
@@ -20,6 +20,10 @@ log = logging.getLogger("ovirt")
 
 # Image transfer constants.
 DOWNLOAD = types.ImageTransferDirection.DOWNLOAD
+RAW = types.DiskFormat.RAW
+COW = types.DiskFormat.COW
+ISO = types.DiskContentType.ISO
+DATA = types.DiskContentType.DATA
 
 
 class Repr:
@@ -57,8 +61,7 @@ def find_disk(con, disk_id):
 
 def add_disk(con, name, provisioned_size, sd_name, id=None,
              initial_size=None, sparse=True, enable_backup=True,
-             content_type=types.DiskContentType.DATA,
-             format=types.DiskFormat.COW):
+             content_type=DATA, format=COW):
     """
     Add a new disk to the storage domain, based on the source image
     information provided.
@@ -255,7 +258,7 @@ def create_transfer(
         backup=backup,
         inactivity_timeout=inactivity_timeout,
         timeout_policy=timeout_policy,
-        format=types.DiskFormat.RAW,
+        format=RAW,
         shallow=shallow)
 
     if isinstance(image, types.Disk):

--- a/ovirt_imageio/client/_tool.py
+++ b/ovirt_imageio/client/_tool.py
@@ -17,6 +17,7 @@ import sys
 from . import _app
 from . import _download
 from . import _options
+from . import _upload
 
 log = logging.getLogger("tool")
 
@@ -24,6 +25,7 @@ log = logging.getLogger("tool")
 def main():
     parser = _options.Parser()
     _download.register(parser)
+    _upload.register(parser)
     args = parser.parse()
 
     logging.basicConfig(

--- a/ovirt_imageio/client/_upload.py
+++ b/ovirt_imageio/client/_upload.py
@@ -1,0 +1,165 @@
+# ovirt-imageio
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""
+Upload commands.
+"""
+
+import os
+from contextlib import closing
+from collections import namedtuple
+
+from . import _api
+from . import _options
+from . import _ovirt
+from . import _ui
+
+
+DiskInfo = namedtuple(
+    "DiskInfo",
+    "name,initial_size,provisioned_size,content_type,format,sparse")
+
+FORMAT_RAW = "raw"
+FORMAT_QCOW2 = "qcow2"
+_DISK_FORMATS = (FORMAT_RAW, FORMAT_QCOW2)
+
+
+def register(parser):
+    cmd = parser.add_sub_command(
+        "upload-disk",
+        help="Upload disk",
+        func=upload_disk)
+
+    cmd.add_argument(
+        "-s", "--storage-domain",
+        required=True,
+        help="Name of the storage domain.")
+
+    cmd.add_argument(
+        "-f", "--format",
+        choices=_DISK_FORMATS,
+        default=FORMAT_QCOW2,
+        help="Upload disk format (default qcow2 for data disks and raw "
+             "for iso disks).")
+
+    cmd.add_argument(
+        "--preallocated",
+        dest="sparse",
+        action="store_false",
+        help="Create preallocated disk. Required when using raw format on "
+             "block based storage domain (iSCSI, FC). ISO images are "
+             "always uploaded to preallocated disk.")
+
+    cmd.add_argument(
+        "--disk-id",
+        type=_options.UUID,
+        help="A UUID for the new disk. If not specified oVirt will "
+             "create a new UUID.")
+
+    cmd.add_argument(
+        "filename",
+        type=_options.File,
+        help="Path to image to upload. Supported formats: raw, qcow2, iso.")
+
+
+def upload_disk(args):
+    with _ui.ProgressBar(phase="inspecting image") as progress:
+        disk_info = _prepare(args)
+        con = _ovirt.connect(args)
+        with closing(con):
+            progress.phase = "creating disk"
+            disk = _ovirt.add_disk(
+                con=con,
+                name=disk_info.name,
+                initial_size=disk_info.initial_size,
+                provisioned_size=disk_info.provisioned_size,
+                sd_name=args.storage_domain,
+                id=args.disk_id,
+                sparse=disk_info.sparse,
+                enable_backup=disk_info.format == _ovirt.COW,
+                content_type=disk_info.content_type,
+                format=disk_info.format)
+
+            progress.phase = "creating transfer"
+            host = _ovirt.find_host(con, args.storage_domain)
+            transfer = _ovirt.create_transfer(con, disk, host=host)
+            try:
+                progress.phase = "uploading image"
+                _api.upload(
+                    args.filename,
+                    transfer.transfer_url,
+                    args.cafile,
+                    buffer_size=args.buffer_size,
+                    progress=progress,
+                    proxy_url=transfer.proxy_url,
+                    max_workers=args.max_workers)
+            except Exception:
+                progress.phase = "cancelling transfer"
+                _ovirt.cancel_transfer(con, transfer)
+                raise
+
+            progress.phase = "finalizing transfer"
+            _ovirt.finalize_transfer(con, transfer, disk)
+        progress.phase = "upload completed"
+
+
+def _prepare(args):
+    # Obtain the image info dictionary.
+    img_info = _api.info(args.filename)
+    if img_info["format"] not in _DISK_FORMATS:
+        raise RuntimeError(f"Unsupported image format {img_info['format']}")
+
+    # Obtain all remaining fields for DiskInfo.
+    if _is_iso(img_info["filename"], img_info["format"]):
+        content_type = _ovirt.ISO
+        # ISO images require raw format to work with cdrom device
+        disk_format = FORMAT_RAW
+    else:
+        content_type = _ovirt.DATA
+        disk_format = args.format
+
+    initial_size = None
+    if disk_format == FORMAT_QCOW2:
+        initial_size = _api.measure(args.filename, disk_format)["required"]
+    name = os.path.splitext(os.path.basename(img_info["filename"]))[0]
+
+    return DiskInfo(
+        name=name,
+        initial_size=initial_size,
+        provisioned_size=img_info["virtual-size"],
+        content_type=content_type,
+        format=_ovirt.COW if disk_format == FORMAT_QCOW2 else _ovirt.RAW,
+        sparse=False if content_type == _ovirt.ISO else args.sparse)
+
+
+def _is_iso(filename, image_format):
+    """
+    Detect if disk content type is ISO
+
+    ISO format structure
+    ---------------------------------------------------------------------------
+    offset    type    value       comment
+    ---------------------------------------------------------------------------
+    0x0000                        system area (e.g. DOS/MBR boot sector)
+    0x8000    int8    0x01        primary volume descriptor type code
+    0x8001    strA    "CD001"     primary volume descriptor indentifier
+    0x8006    int8    0x01        primary volume desctptor version
+    0x8007            0x00        unused field
+
+    See https://wiki.osdev.org/ISO_9660#Overview_and_caveats for more info.
+
+    Returns:
+        bool: Source image is ISO
+    """
+    if image_format == FORMAT_RAW:
+        with open(filename, "rb") as file:
+            file.seek(0x8000)
+            primary_volume_descriptor = file.read(8)
+        if primary_volume_descriptor == b"\x01CD001\x01\x00":
+            return True
+    return False

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -8,6 +8,7 @@
 
 import getpass
 import os
+import uuid
 
 import pytest
 
@@ -94,6 +95,21 @@ def test_size_values():
     assert str(validate.default) == "2m"
     assert validate.maximum == 1 * GiB
     assert str(validate.maximum) == "1g"
+
+
+def test_uuid_valid():
+    validate = _options.UUID
+    id = str(uuid.uuid4())
+    assert validate(id) == id
+
+
+def test_uuid_invalid():
+    validate = _options.UUID
+    id = "invalid uuid"
+    with pytest.raises(ValueError) as e:
+        validate(id)
+    assert id in str(e.value)
+    assert "UUID" in str(e.value)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add upload-disk sub-command for upload disks.
```
$ ./ovirt-img upload-disk -h
usage: ovirt-img upload-disk [-h] [-c CONFIG] [--engine-url ENGINE_URL]
                             [--username USERNAME]
                             [--password-file PASSWORD_FILE] [--cafile CAFILE]
                             [--log-file LOG_FILE] [--log-level LOG_LEVEL]
                             [--max-workers MAX_WORKERS]
                             [--buffer-size BUFFER_SIZE] -s STORAGE_DOMAIN
                             [-f {raw,qcow2}] [--preallocated] [--disk-id ID]
                             filename

positional arguments:
  filename              Path to image to upload. Supported formats: raw,
                        qcow2, iso.

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        If set, read specified section from the configuration
                        file.
  --engine-url ENGINE_URL
                        ovirt-engine URL. If not set, read from the specified
                        config section (required).
  --username USERNAME   ovirt-engine username. If not set, read from the
                        specified config section (required).
  --password-file PASSWORD_FILE
                        Read ovirt-engine password from file. If not set, read
                        password from the specified config section, or prompt
                        the user for the password.
  --cafile CAFILE       Path to ovirt-engine CA certificate. If not set, read
                        from the specified config section
  --log-file LOG_FILE   Log to file instead of stderr.
  --log-level LOG_LEVEL
                        Log level (choices: {debug, info, warning, error},
                        default: warning).
  --max-workers MAX_WORKERS
                        Maximum number of workers (range: 1-8, default: 4).
  --buffer-size BUFFER_SIZE
                        Buffer size per worker (range: 64k-16m, default: 4m).
  -s STORAGE_DOMAIN, --storage-domain STORAGE_DOMAIN
                        Name of the storage domain.
  -f {raw,qcow2}, --format {raw,qcow2}
                        Upload image format (default qcow2 for data disks and
                        raw for iso disks).
  --preallocated        Create preallocated disk. Required when using raw
                        format on block based storage domain (iSCSI, FC). ISO
                        images are always uploaded to preallocated disk.
--disk-id ID       A UUID for the new disk. If not specified oVirt will
                        create a new UUID.
```
```
$ ./ovirt-img upload-disk --config engine --storage-domain iscsi-sd disk1.qcow2
[ ----  ] 0 bytes, 0.00 s, 0 bytes/s | inspecting image
[ ----  ] 0 bytes, 0.01 s, 0 bytes/s | creating disk
[ ----  ] 0 bytes, 6.39 s, 0 bytes/s | creating transfer
[  38%  ] 2.29 GiB, 15.99 s, 146.59 MiB/s | uploading image
[ 100%  ] 6.00 GiB, 22.88 s, 268.56 MiB/s | finalizing transfer
[ 100%  ] 6.00 GiB, 33.02 s, 186.07 MiB/s | upload completed
```
Possible combinations:
Content | Storage | Backup | Format | Allocation   | Allowed
------|--------|--------|--------|--------------|-------------------
data | block   | yes    | qcow2  | sparse       | :heavy_check_mark:
data | block   | yes    | qcow2  | preallocated | :heavy_check_mark:
data | block   | no     | raw    | sparse       | :x:
data | block   | no     | raw    | preallocated | :heavy_check_mark:
data | file    | yes    | qcow2  | sparse       | :heavy_check_mark:
data | file    | yes    | qcow2  | preallocated | :heavy_check_mark:
data | file    | no     | raw    | sparse       | :heavy_check_mark:
data | file    | no     | raw    | sparse       | :heavy_check_mark:
iso     | block   | no     | raw    | preallocated | :heavy_check_mark:
iso     | file   | no     | raw    | preallocated | :heavy_check_mark:

Note: Source allocation policies omitted as they make no difference.

Related: https://github.com/oVirt/ovirt-imageio/issues/72
Signed-off-by: Albert Esteve <aesteve@redhat.com>