### PR TITLE
ovirt-img: fix logging config

### DIFF
--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -117,8 +117,7 @@ class Parser:
             name="log_file",
             args=["--log-file"],
             config=True,
-            default="/dev/stderr",
-            help="Log file name (default: /dev/stderr).",
+            help="Log to file instead of stderr.",
         ),
         Option(
             name="log_level",

--- a/ovirt_imageio/client/_ovirt.py
+++ b/ovirt_imageio/client/_ovirt.py
@@ -46,7 +46,7 @@ def connect(args):
         username=args.username,
         password=args.password,
         ca_file=args.cafile,
-        log=log if args.log_file else None,
+        log=log,
         debug=args.log_level == "debug")
 
 

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -185,7 +185,7 @@ def test_config_required(config, monkeypatch):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile is None
-    assert args.log_file == "/dev/stderr"
+    assert args.log_file is None
     assert args.log_level == "warning"
 
     # No --password-file or config password: use getpass.getpass().


### PR DESCRIPTION
In ovit-img log_file defaults to /dev/stderr fd,
and is passed to logging configurator through
filename argument.

However, this is not correct, filename only is
used for files. File descriptions shall go
as stream parameters.

Otherwise the tool breaks with
'OSError: [Errno 29] Illegal seek'
in an internal logging module.
Reproduced with Python 3.6 in CentOS Stream 8.

To solve it, default log_file to None instead, so
that logging configuration does not use a filename
and falls back to the stream argument, which defaults
to stderr.

Fixes: #113 
Fixes: a2bbe122cc85d08dd5ab60e6d2438b54b1f11e6b
Signed-off-by: Albert Esteve <aesteve@redhat.com>