### PR TITLE
client: Show progress phase

### DIFF
--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -28,7 +28,7 @@ class ProgressBar:
             width (int): width of progress bar in characters (default 79)
             now (callable): callable returning current time for testing.
         """
-        self.size = size
+        self._size = size
         self._output = output
         # TODO: use current terminal width instead.
         self._width = width
@@ -43,6 +43,19 @@ class ProgressBar:
 
         # The first update can take some time.
         self._draw()
+
+    @property
+    def size(self):
+        return self._size
+
+    @size.setter
+    def size(self, n):
+        with self._lock:
+            if self._closed:
+                return
+            if self._size != n:
+                self._size = n
+                self._draw()
 
     def update(self, n):
         """
@@ -61,8 +74,8 @@ class ProgressBar:
             if self._closed:
                 return
             self._done += n
-            if self.size:
-                new_value = int(self._done / self.size * 100)
+            if self._size:
+                new_value = int(self._done / self._size * 100)
                 if new_value > self._value:
                     self._value = new_value
                     self._draw()
@@ -75,7 +88,7 @@ class ProgressBar:
 
     def _draw(self, last=False):
         elapsed = self._now() - self._start
-        progress = f"{max(0, self._value):3d}%" if self.size else "----"
+        progress = f"{max(0, self._value):3d}%" if self._size else "----"
         done = util.humansize(self._done)
         rate = util.humansize((self._done / elapsed) if elapsed else 0)
 

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -15,11 +15,13 @@ from .. _internal import util
 
 class ProgressBar:
 
-    def __init__(self, phase=None, size=None, output=sys.stdout, step=None,
-                 width=79, now=time.monotonic):
+    def __init__(self, phase=None, error_phase="command failed", size=None,
+                 output=sys.stdout, step=None, width=79, now=time.monotonic):
         """
         Arguments:
             phase (str): short description of the current phase.
+            error_phase (str): phase to set when code run under the context
+                manager has failed.
             size (int): total number of bytes. If size is unknown when
                 creating, progress value is not displayed. The size can be set
                 later to enable progress display.
@@ -30,6 +32,7 @@ class ProgressBar:
             now (callable): callable returning current time for testing.
         """
         self._phase = phase
+        self._error_phase = error_phase
         self._size = size
         self._output = output
         # TODO: use current terminal width instead.
@@ -123,4 +126,7 @@ class ProgressBar:
         return self
 
     def __exit__(self, t, v, tb):
+        # If an exception was raised in the caller code, show a failure.
+        if t is not None:
+            self.phase = self._error_phase
         self.close()

--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -37,45 +37,39 @@ def test_draw():
 
     # Size is unknown at this point.
     pb = client.ProgressBar(output=f, now=fake_time)
-    assert f.last == (
-        "[ ---- ] 0 bytes, 0.00 seconds, 0 bytes/s".ljust(79) + "\r"
-    )
+    line = "[ ---- ] 0 bytes, 0.00 seconds, 0 bytes/s"
+    assert f.last == line.ljust(79) + "\r"
 
     # Size was updated, but no bytes were transfered yet.
     fake_time.now += 0.1
     pb.size = 3 * GiB
     pb.update(0)
-    assert f.last == (
-        "[   0% ] 0 bytes, 0.10 seconds, 0 bytes/s".ljust(79) + "\r"
-    )
+    line = "[   0% ] 0 bytes, 0.10 seconds, 0 bytes/s"
+    assert f.last == line.ljust(79) + "\r"
 
     # Write some data...
     fake_time.now += 1.0
     pb.update(512 * MiB)
-    assert f.last == (
-        "[  16% ] 512.00 MiB, 1.10 seconds, 465.45 MiB/s".ljust(79) + "\r"
-    )
+    line = "[  16% ] 512.00 MiB, 1.10 seconds, 465.45 MiB/s"
+    assert f.last == line.ljust(79) + "\r"
 
     # Write zeros (much faster)...
     fake_time.now += 0.2
     pb.update(2 * GiB)
-    assert f.last == (
-        "[  83% ] 2.50 GiB, 1.30 seconds, 1.92 GiB/s".ljust(79) + "\r"
-    )
+    line = "[  83% ] 2.50 GiB, 1.30 seconds, 1.92 GiB/s"
+    assert f.last == line.ljust(79) + "\r"
 
     # More data, slow down again...
     fake_time.now += 1.0
     pb.update(512 * MiB)
-    assert f.last == (
-        "[ 100% ] 3.00 GiB, 2.30 seconds, 1.30 GiB/s".ljust(79) + "\r"
-    )
+    line = "[ 100% ] 3.00 GiB, 2.30 seconds, 1.30 GiB/s"
+    assert f.last == line.ljust(79) + "\r"
 
     # Flush takes some time, lowering final rate.
     fake_time.now += 0.1
     pb.close()
-    assert f.last == (
-        "[ 100% ] 3.00 GiB, 2.40 seconds, 1.25 GiB/s".ljust(79) + "\n"
-    )
+    line = "[ 100% ] 3.00 GiB, 2.40 seconds, 1.25 GiB/s"
+    assert f.last == line.ljust(79) + "\n"
 
 
 def test_with_size():
@@ -83,9 +77,8 @@ def test_with_size():
     f = FakeFile()
 
     client.ProgressBar(size=3 * GiB, output=f, now=fake_time)
-    assert f.last == (
-        "[   0% ] 0 bytes, 0.00 seconds, 0 bytes/s".ljust(79) + "\r"
-    )
+    line = "[   0% ] 0 bytes, 0.00 seconds, 0 bytes/s"
+    assert f.last == line.ljust(79) + "\r"
 
 
 def test_close():

--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -43,7 +43,6 @@ def test_draw():
     # Size was updated, but no bytes were transferred yet.
     fake_time.now += 0.1
     pb.size = 3 * GiB
-    pb.update(0)
     line = "[   0% ] 0 bytes, 0.10 seconds, 0 bytes/s"
     assert f.last == line.ljust(79) + "\r"
 
@@ -87,11 +86,16 @@ def test_close():
     pb.size = 1 * GiB
     pb.update(512 * MiB)
     pb.close()
+    f.last = None
 
     # Once closed, update does not redraw.
-    f.last = None
     pb.update(512 * MiB)
     assert f.last is None
+
+    # Changing size does nothing.
+    pb.size = 2 * GiB
+    assert f.last is None
+    assert pb.size == 1 * GiB
 
     # Closing twice does not redraw.
     pb.close()

--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -6,6 +6,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import pytest
+
 from ovirt_imageio import client
 from ovirt_imageio._internal.units import MiB, GiB
 
@@ -139,3 +141,29 @@ def test_contextmanager():
         assert f.last.endswith("\r")
 
     assert f.last.endswith("\n")
+
+
+def test_error_phase_default():
+    f = FakeFile()
+    pb = client.ProgressBar(phase="running command", size=GiB, output=f)
+    with pytest.raises(RuntimeError):
+        with pb:
+            raise RuntimeError
+
+    assert f.last.endswith("\n")
+    assert pb.phase == "command failed"
+
+
+def test_error_phase_custom():
+    f = FakeFile()
+    pb = client.ProgressBar(
+        phase="starting operation",
+        error_phase="operation failed",
+        size=GiB,
+        output=f)
+    with pytest.raises(RuntimeError):
+        with pb:
+            raise RuntimeError
+
+    assert f.last.endswith("\n")
+    assert pb.phase == "operation failed"

--- a/test/client_ui_test.py
+++ b/test/client_ui_test.py
@@ -40,7 +40,7 @@ def test_draw():
     line = "[ ---- ] 0 bytes, 0.00 seconds, 0 bytes/s"
     assert f.last == line.ljust(79) + "\r"
 
-    # Size was updated, but no bytes were transfered yet.
+    # Size was updated, but no bytes were transferred yet.
     fake_time.now += 0.1
     pb.size = 3 * GiB
     pb.update(0)


### PR DESCRIPTION
Transferring an image include several phases that may take several
seconds, and we want to show what the tool is doing. When we finish, we
want to show that the operation was completed. If we failed, we want to
show a short failure message even if we use log errors to file.

Add an optional phase argument to ProgressBar. If the phase is set, it
is displayed at the end:

    [ ---- ] 0 bytes, 0.00 s, 0 bytes/s | setting up

The caller can change the phase by setting a new value:

    pb.phase = "downloading image"

This will redraw the progress bar:

    [   0% ] 0 bytes, 0.00 s, 0 bytes/s | downloading image

This change only adds the infrastructure, no change yet in the actual
commands.
