### PR TITLE
Terminate gracefully on signals

### DIFF
--- a/ovirt_imageio/_internal/io.py
+++ b/ovirt_imageio/_internal/io.py
@@ -251,7 +251,7 @@ class Worker:
         except Exception as e:
             self._errors.append(e)
             self._queue.close()
-            log.exception("Worker %s failed", self._name)
+            log.debug("Worker %s failed: %s", self._name, e)
         else:
             log.debug("Worker %s finished", self._name)
 

--- a/ovirt_imageio/client/_api.py
+++ b/ovirt_imageio/client/_api.py
@@ -20,16 +20,17 @@ from contextlib import contextmanager
 from urllib.parse import urlparse
 
 from .. _internal import blkhash
-from .. _internal import io
 from .. _internal import qemu_img
 from .. _internal import qemu_nbd
 from .. _internal.backends import http, nbd
 from .. _internal.handlers import checksum as _checksum
 from .. _internal.nbd import UnixAddress
 
+from . import _io
+
 # API constants.
-BUFFER_SIZE = io.BUFFER_SIZE
-MAX_WORKERS = io.MAX_WORKERS
+BUFFER_SIZE = _io.BUFFER_SIZE
+MAX_WORKERS = _io.MAX_WORKERS
 
 log = logging.getLogger("client")
 
@@ -95,7 +96,7 @@ def upload(filename, url, cafile, buffer_size=BUFFER_SIZE, secure=True,
                 backing_chain=backing_chain) as src:
 
             # Upload the image to the server.
-            io.copy(
+            _io.copy(
                 src,
                 dst,
                 max_workers=max_workers,
@@ -173,7 +174,7 @@ def download(url, filename, cafile, fmt="qcow2", incremental=False,
         with _open_nbd(filename, fmt, shared=max_workers) as dst:
 
             # Download the image from the server to the local image.
-            io.copy(
+            _io.copy(
                 src,
                 dst,
                 dirty=incremental,

--- a/ovirt_imageio/client/_app.py
+++ b/ovirt_imageio/client/_app.py
@@ -1,0 +1,43 @@
+# ovirt-imageio
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""
+Client application global state.
+"""
+
+import signal
+
+_termination_signal = None
+
+
+class TerminatedBySignal(Exception):
+
+    def __init__(self, signo):
+        self.signal = signo
+
+    def __str__(self):
+        return f"Terminated by signal {self.signal}"
+
+
+def check_terminated():
+    """
+    Raise TerminatedBySignal if termination signal was received.
+    """
+    if _termination_signal is not None:
+        raise TerminatedBySignal(_termination_signal)
+
+
+def setup_signals():
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+
+def _handle_signal(signo, frame):
+    global _termination_signal
+    if _termination_signal is None:
+        _termination_signal = signo

--- a/ovirt_imageio/client/_app.py
+++ b/ovirt_imageio/client/_app.py
@@ -13,6 +13,7 @@ Client application global state.
 import signal
 
 _termination_signal = None
+_registered_signals = False
 
 
 class TerminatedBySignal(Exception):
@@ -33,8 +34,17 @@ def check_terminated():
 
 
 def setup_signals():
+    global _registered_signals
     signal.signal(signal.SIGINT, _handle_signal)
     signal.signal(signal.SIGTERM, _handle_signal)
+    _registered_signals = True
+
+
+def is_handling_signals():
+    """
+    Return True if the application registered signals handlers.
+    """
+    return _registered_signals
 
 
 def _handle_signal(signo, frame):

--- a/ovirt_imageio/client/_io.py
+++ b/ovirt_imageio/client/_io.py
@@ -20,6 +20,8 @@ from .. _internal import util
 from .. _internal.backends import Wrapper
 from .. _internal.units import MiB
 
+from . import _app
+
 # Limit maximum zero and copy size to spread the workload better to multiple
 # workers and ensure frequent progress updates when handling large extents.
 MAX_ZERO_SIZE = 128 * MiB
@@ -239,6 +241,7 @@ class Worker:
             with closing(handler):
                 while True:
                     req = self._queue.get()
+                    _app.check_terminated()
                     if req.op is ZERO:
                         handler.zero(req)
                     elif req.op is COPY:

--- a/ovirt_imageio/client/_io.py
+++ b/ovirt_imageio/client/_io.py
@@ -16,9 +16,9 @@ from collections import deque, namedtuple
 from contextlib import closing
 from functools import partial
 
-from . import util
-from . backends import Wrapper
-from .units import MiB
+from .. _internal import util
+from .. _internal.backends import Wrapper
+from .. _internal.units import MiB
 
 # Limit maximum zero and copy size to spread the workload better to multiple
 # workers and ensure frequent progress updates when handling large extents.

--- a/ovirt_imageio/client/_tool.py
+++ b/ovirt_imageio/client/_tool.py
@@ -11,9 +11,14 @@ Tool for transferring disk images.
 """
 
 import logging
+import signal
+import sys
 
-from . import _options
+from . import _app
 from . import _download
+from . import _options
+
+log = logging.getLogger("tool")
 
 
 def main():
@@ -27,7 +32,15 @@ def main():
         format="%(asctime)s %(levelname)-7s (%(threadName)s) [%(name)s] "
                "%(message)s")
 
-    # XXX Setup signal handlers.
-    # XXX Handle commands errors.
+    _app.setup_signals()
 
-    args.command(args)
+    try:
+        args.command(args)
+    except _app.TerminatedBySignal as e:
+        # SIGINT is likey result of Control+C in the shell.
+        level = logging.INFO if e.signal == signal.SIGINT else logging.ERROR
+        log.log(level, "Exiting: %s", e)
+        sys.exit(128 + e.signal)
+    except Exception:
+        log.exception("Command failed")
+        sys.exit(1)


### PR DESCRIPTION
Register signals handlers before running the command, and handle
signals gracefully.

When terminated by signal, log an error instead of a traceback, since
this is expected condition. Since termination by SIGINT is typically
initiated by a user log info level message.

For any other error, log a traceback to make it easy to report useful
bug reports.
