### PR TITLE
ovirt-img: add name option for disk

### DIFF
--- a/ovirt_imageio/client/_upload.py
+++ b/ovirt_imageio/client/_upload.py
@@ -58,8 +58,13 @@ def register(parser):
     cmd.add_argument(
         "--disk-id",
         type=_options.UUID,
-        help="A UUID for the new disk. If not specified oVirt will "
+        help="A UUID for the new disk. If not specified, oVirt will "
              "create a new UUID.")
+
+    cmd.add_argument(
+        "--name",
+        help="Alias name for the new disk. If not specified, name will "
+             "correspond with the image filename.")
 
     cmd.add_argument(
         "filename",
@@ -126,7 +131,9 @@ def _prepare(args):
     initial_size = None
     if disk_format == FORMAT_QCOW2:
         initial_size = _api.measure(args.filename, disk_format)["required"]
-    name = os.path.splitext(os.path.basename(img_info["filename"]))[0]
+    name = args.name
+    if name is None:
+        name = os.path.splitext(os.path.basename(img_info["filename"]))[0]
 
     return DiskInfo(
         name=name,


### PR DESCRIPTION
Add '--name' option to the 'upload-disk' command
to allow users to define a custom alias name
for the new uploaded disk. If ommited, default
behaviour remains, taking the source image filename
as an alias.
```
usage: ovirt-img upload-disk [-h] [-c CONFIG] [--engine-url ENGINE_URL]
                             [--username USERNAME]
                             [--password-file PASSWORD_FILE] [--cafile CAFILE]
                             [--log-file LOG_FILE] [--log-level LOG_LEVEL]
                             [--max-workers MAX_WORKERS]
                             [--buffer-size BUFFER_SIZE] -s STORAGE_DOMAIN
                             [-f {raw,qcow2}] [--preallocated]
                             [--disk-id DISK_ID] [--name NAME]
                             filename
....
  --name NAME           Alias name for the new disk. If not specified, name
                        will correspond with the image filename.
```
Closes: #121
Signed-off-by: Albert Esteve <aesteve@redhat.com>