### PR TITLE
ovirt-img: add --version option

### DIFF
--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -13,6 +13,7 @@ Tool options.
 import getpass
 from collections import namedtuple
 
+from .. _internal import version
 from .. _internal.units import KiB, MiB, GiB, TiB
 from . _api import MAX_WORKERS, BUFFER_SIZE
 
@@ -135,6 +136,10 @@ class Parser:
         self._parser = argparse.ArgumentParser(
             description="Transfer disk images")
         self._parser.set_defaults(command=None)
+        self._parser.add_argument(
+            '--version',
+            action='version',
+            version=f'%(prog)s {version.string}')
         self._commands = self._parser.add_subparsers(title="commands")
 
     def add_sub_command(self, name, help, func, transfer_options=True):

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -13,6 +13,7 @@ import uuid
 import pytest
 
 from ovirt_imageio._internal.units import KiB, MiB, GiB, TiB
+from ovirt_imageio._internal import version
 from ovirt_imageio.client import _options
 
 
@@ -337,3 +338,13 @@ def test_auto_help(capsys):
     err2 = capsys.readouterr().err
 
     assert err1 == err2
+
+
+def test_version(capsys):
+    parser = _options.Parser()
+    parser.add_sub_command("test", "help", lambda x: None)
+    with pytest.raises(SystemExit):
+        parser.parse(["--version"])
+    out = capsys.readouterr().out
+
+    assert version.string in out


### PR DESCRIPTION
Add --version option to ovirt-img tool to show current version:
```
$ ./ovirt-img -h
usage: ovirt-img [-h] [--version] {download-disk,upload-disk} ...

Transfer disk images

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit

commands:
  {download-disk,upload-disk}
    download-disk       Download disk
    upload-disk         Upload disk
```
```
$ ./ovirt-img --version
ovirt-img 2.4.6
```
Fixes: #125
Signed-off-by: Albert Esteve <aesteve@redhat.com>