### PR TITLE
containers: Specify COPR chroot explicitly

### DIFF
--- a/containers/centos-9.containerfile
+++ b/containers/centos-9.containerfile
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream9
 # Runtime packages.
 RUN echo v1 \
     && dnf install -y dnf-plugins-core \
-    && dnf copr enable -y ovirt/ovirt-master-snapshot \
+    && dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-9 \
     && dnf install -y ovirt-release-master \
     && dnf install -y \
         createrepo_c \


### PR DESCRIPTION
A recent change to DNF COPR plugin [1] makes 'epel-9' the default chroot
used for CentOS Stream 9. Let's specify the 'centos-stream-9' chroot
name that we use in oVirt's COPR expliclty.

[1] https://github.com/rpm-software-management/dnf-plugins-core/pull/459

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>