### PR TITLE
http: avoid double slashes in url

### DIFF
--- a/test/backends/http_test.py
+++ b/test/backends/http_test.py
@@ -38,7 +38,7 @@ def http_server(tmp_pki):
     server.socket = ctx.wrap_socket(server.socket, server_side=True)
 
     server.url = urlparse(
-        "https://localhost:{}/".format(server.server_port))
+        "https://localhost:{}/images/ticket-id".format(server.server_port))
     server.cafile = tmp_pki.cafile
     server.app = http.Router([])
 
@@ -79,7 +79,7 @@ class Handler:
         self.dirty = False
         self.requests = 0
 
-        router = http.Router([("/(.*)", self)])
+        router = http.Router([(r"/images/(.*)", self)])
         http_server.app = router
         if uhttp_server:
             uhttp_server.app = router
@@ -197,7 +197,7 @@ class Daemon(Handler):
         """
         Override to dispatch "GET /extents" resource.
         """
-        if path == "/extents":
+        if path == "ticket-id/extents":
             self.requests += 1
             context = req.query.get("context", "zero")
             self._extents(resp, context)


### PR DESCRIPTION
Recent HTTPRequestHandler changes avoid urls that
start with '//' to protect against open redirect
attacks (see https://github.com/python/cpython/commit/4abab6b603dd38bec1168e9a37c40a48ec89508e).

Server url in the http test have no path,
therefore the handler that is used in the
test receives the root path, resulting in
requests starting with '//' when the Backend
tries to get the extents, which break in the
pipelines for recent Python 3.10 versions.

This is not a realistic scenario and not
something the library needs to handle.
Is better to change the url to a more
realistic scenario, and since we want
to test image handling, have
`/images/ticket-id` in the url path.

Signed-off-by: Albert Esteve <aesteve@redhat.com>