### PR TITLE
ovirt-img: disk creation loop

### DIFF
--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -24,6 +24,9 @@ import sys
 import uuid
 
 
+ADD_DISK_TIMEOUT = 120
+
+
 class Choices:
 
     def __init__(self, name, values):
@@ -115,6 +118,12 @@ class Parser:
             config=True,
             help=("Path to ovirt-engine CA certificate. If not set, read "
                   "from the specified config section"),
+        ),
+        Option(
+            name="disk_timeout",
+            config=True,
+            type=int,
+            default=ADD_DISK_TIMEOUT,
         ),
         Option(
             name="log_file",

--- a/ovirt_imageio/client/_ovirt.py
+++ b/ovirt_imageio/client/_ovirt.py
@@ -16,6 +16,8 @@ import time
 import ovirtsdk4 as sdk
 from ovirtsdk4 import types
 
+from . _options import ADD_DISK_TIMEOUT
+
 log = logging.getLogger("ovirt")
 
 # Image transfer constants.
@@ -61,7 +63,7 @@ def find_disk(con, disk_id):
 
 def add_disk(con, name, provisioned_size, sd_name, id=None,
              initial_size=None, sparse=True, enable_backup=True,
-             content_type=DATA, format=COW):
+             content_type=DATA, format=COW, timeout=ADD_DISK_TIMEOUT):
     """
     Add a new disk to the storage domain, based on the source image
     information provided.
@@ -79,6 +81,8 @@ def add_disk(con, name, provisioned_size, sd_name, id=None,
         content_type (ovirtsdk4.types.DiskContentType): Content type for the
             new disk.
         format (ovirtsdk4.types.DiskFormat): Format of the new disk.
+        timeout (int, optional): number of seconds to wait for
+            disk to be created.
 
     Returns:
         ovirtsdk4.types.Disk
@@ -108,7 +112,7 @@ def add_disk(con, name, provisioned_size, sd_name, id=None,
             ]
         )
     )
-    _wait_for_disk(con, disk.id)
+    _wait_for_disk(con, disk.id, timeout)
     return disk
 
 
@@ -414,9 +418,8 @@ def finalize_transfer(con, transfer, disk, timeout=300):
              transfer.id, time.monotonic() - start)
 
 
-def _wait_for_disk(con, disk_id):
+def _wait_for_disk(con, disk_id, timeout):
     log.info("Waiting for disk %s", disk_id)
-    timeout = 120
     start = time.monotonic()
     deadline = start + timeout
     disk_service = _disk_service(con, disk_id)

--- a/ovirt_imageio/client/_ovirt.py
+++ b/ovirt_imageio/client/_ovirt.py
@@ -425,7 +425,11 @@ def _wait_for_disk(con, disk_id):
         if time.monotonic() > deadline:
             raise RuntimeError(f"Timeout reached waiting for disk {disk_id}")
 
-        if disk_service.get().status == types.DiskStatus.OK:
+        disk = disk_service.get()
+        if disk.status == types.DiskStatus.ILLEGAL:
+            raise RuntimeError(f"Disk {disk_id} became ILLEGAL")
+
+        if disk.status == types.DiskStatus.OK:
             break
 
 

--- a/ovirt_imageio/client/_upload.py
+++ b/ovirt_imageio/client/_upload.py
@@ -88,7 +88,8 @@ def upload_disk(args):
                 sparse=disk_info.sparse,
                 enable_backup=disk_info.format == _ovirt.COW,
                 content_type=disk_info.content_type,
-                format=disk_info.format)
+                format=disk_info.format,
+                timeout=args.disk_timeout)
 
             progress.phase = "creating transfer"
             host = _ovirt.find_host(con, args.storage_domain)

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -123,6 +123,7 @@ engine_url = https://engine.com
 username = username
 password = password
 cafile = /engine.pem
+disk_timeout = 200
 log_file = /var/log/ovirt-img/engine.log
 log_level = info
 
@@ -158,6 +159,7 @@ def test_config_all(config):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile == "/engine.pem"
+    assert args.disk_timeout == 200
     assert args.log_file == "/var/log/ovirt-img/engine.log"
     assert args.log_level == "info"
     assert args.max_workers == 4
@@ -187,6 +189,7 @@ def test_config_all_override(config, tmpdir):
     assert args.engine_url == "https://engine2.com"
     assert args.username == "username2"
     assert args.cafile == "/engine2.pem"
+    assert args.disk_timeout == 200
     assert args.log_file == "test.log"
     assert args.log_level == "debug"
     assert args.max_workers == 4
@@ -206,6 +209,7 @@ def test_config_required(config, monkeypatch):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile is None
+    assert args.disk_timeout == 120
     assert args.log_file is None
     assert args.log_level == "warning"
     assert args.max_workers == 4
@@ -233,6 +237,7 @@ def test_config_required_override(config, tmpdir):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile == "/engine2.pem"
+    assert args.disk_timeout == 120
     assert args.log_file == "test.log"
     assert args.log_level == "debug"
     assert args.max_workers == 4


### PR DESCRIPTION
On disk-upload, ovirt-img  probes a disk after
creation during a fixed time, until it reaches an
OK status (or timeout).

If there is an error in the creation and disk becomes
DiskStatus.ILLEGAL, users have to wait for the timeout.

We need to handle this error status and fail loudly.

Add an option, only available through config file,
to change the timeout waiting for disk creation.

This is a fine-gran configuration that should be
fine as default for most cases, but may be
interesting to modify it for stress tests,
or slow networks, etc.

Fixes: https://github.com/oVirt/ovirt-imageio/issues/117
Signed-off-by: Albert Esteve <aesteve@redhat.com>