### PR TITLE
ci: build containers automatically every week

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -39,3 +39,25 @@ jobs:
       - name: Print image url
         if: ${{ env.can_push == 'true' }}
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman
+      - name: Build container images
+        run: make container
+      - name: Push to Quay.io
+        if: ${{ env.can_push == 'true' }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ovirt/ovirt-imageio
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME  }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        if: ${{ env.can_push == 'true' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Red Hat, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+name: Containers
+on:
+  # Be able to run the job manually when needed
+  # (Actions -> Containers -> Run workflow)
+  workflow_dispatch:
+  # Build every week on Monday 00:00
+  schedule:
+    - cron:  '0 0 * * 1'
+env:
+  IMAGE_REGISTRY: quay.io
+  can_push: ${{ github.repository_owner == 'oVirt' }}
+jobs:
+  test-containers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container: [ centos-8 centos-9 fedora-35 fedora-36 ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install podman
+      - name: Build container images
+        working-directory: containers
+        run: make ${{ matrix.container }}
+      - name: Push to Quay.io
+        if: ${{ env.can_push == 'true' }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ovirt/imageio-test-${{ matrix.container }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME  }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        if: ${{ env.can_push == 'true' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Build project containers (currently four)
and push them every week to update at least
the underlaying OS.

Fixes: #13
Signed-off-by: Albert Esteve <aesteve@redhat.com>