### PR TITLE
update userstorage version

### DIFF
--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -1,2 +1,2 @@
 tox>=3.24
-userstorage>=0.4
+userstorage>=0.5.1

--- a/test/backends/file_test.py
+++ b/test/backends/file_test.py
@@ -44,8 +44,9 @@ KERNEL_VERSION = tuple(map(int, os.uname()[2].split(".")[:2]))
     ids=lambda x: str(x[0]),
 )
 def user_file(request):
-    with storage.Backend(*request.param) as backend:
-        yield backend
+    backend, can_detect_sector_size = request.param
+    with backend:
+        yield storage.Backend(backend, can_detect_sector_size)
 
 
 def test_debugging_interface(user_file):

--- a/test/backends/nbd_test.py
+++ b/test/backends/nbd_test.py
@@ -33,8 +33,9 @@ BACKENDS = userstorage.load_config("storage.py").BACKENDS
     ids=str
 )
 def user_file(request):
-    with storage.Backend(request.param) as backend:
-        yield backend
+    backend = request.param
+    with backend:
+        yield storage.Backend(backend)
 
 
 def test_debugging_interface(nbd_server):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,10 +15,14 @@ import urllib.parse
 from collections import namedtuple
 
 import pytest
+import userstorage
 
 from ovirt_imageio._internal import nbd
 from ovirt_imageio._internal import qemu_nbd
 from ovirt_imageio._internal import util
+
+# Mark tests with xfail if userstorage is missing
+userstorage.missing_handler = pytest.xfail
 
 log = logging.getLogger("test")
 

--- a/test/handlers/checksum_test.py
+++ b/test/handlers/checksum_test.py
@@ -21,7 +21,6 @@ from ovirt_imageio._internal import server
 
 from .. import testutil
 from .. import http
-from .. import storage
 
 BACKENDS = userstorage.load_config("storage.py").BACKENDS
 ALGORITHMS = frozenset(hashlib.algorithms_available)
@@ -35,7 +34,8 @@ ALGORITHMS = frozenset(hashlib.algorithms_available)
     ids=str
 )
 def user_file(request):
-    with storage.Backend(request.param) as backend:
+    backend = request.param
+    with backend:
         yield backend
 
 

--- a/test/handlers/extents_test.py
+++ b/test/handlers/extents_test.py
@@ -18,7 +18,6 @@ from ovirt_imageio._internal import server
 
 from .. import testutil
 from .. import http
-from .. import storage
 
 BACKENDS = userstorage.load_config("storage.py").BACKENDS
 
@@ -31,7 +30,8 @@ BACKENDS = userstorage.load_config("storage.py").BACKENDS
     ids=str
 )
 def user_file(request):
-    with storage.Backend(request.param) as backend:
+    backend = request.param
+    with backend:
         yield backend
 
 

--- a/test/nbd_test.py
+++ b/test/nbd_test.py
@@ -24,7 +24,6 @@ from ovirt_imageio._internal import qemu_nbd
 from . import backup
 from . import ci
 from . import distro
-from . import storage
 from . import testutil
 
 from . marks import (
@@ -47,7 +46,8 @@ log = logging.getLogger("test")
     ids=str
 )
 def user_file(request):
-    with storage.Backend(request.param) as backend:
+    backend = request.param
+    with backend:
         yield backend
 
 

--- a/test/ops_test.py
+++ b/test/ops_test.py
@@ -32,8 +32,9 @@ BACKENDS = userstorage.load_config("storage.py").BACKENDS
     ids=str
 )
 def user_file(request):
-    with storage.Backend(request.param) as backend:
-        yield backend
+    backend = request.param
+    with backend:
+        yield storage.Backend(backend)
 
 
 # Common offset and size parameters.

--- a/test/storage.py
+++ b/test/storage.py
@@ -8,28 +8,29 @@
 
 import urllib.parse
 
-import pytest
-
 
 class Backend:
     """
-    Wrap a userstorage.Backend, adding a url and context manager interface to
-    simplify fixtures.
+    Wrap a userstorage.Backend, adding a url and the can_detect_sector_size
+    attribute.
     """
 
     def __init__(self, storage, can_detect_sector_size=True):
-        if not storage.exists():
-            pytest.xfail("Storage {} is not available".format(storage.name))
-
         self._storage = storage
-        self.path = storage.path
         self.url = urllib.parse.urlparse("file:" + storage.path)
-        self.sector_size = storage.sector_size
         self.can_detect_sector_size = can_detect_sector_size
 
+    @property
+    def path(self):
+        return self._storage.path
+
+    @property
+    def sector_size(self):
+        return self._storage.sector_size
+
     def __enter__(self):
-        self._storage.setup()
+        self._storage.__enter__()
         return self
 
     def __exit__(self, *args):
-        self._storage.teardown()
+        self._storage.__exit__(*args)

--- a/test/storage.py
+++ b/test/storage.py
@@ -27,10 +27,3 @@ class Backend:
     @property
     def sector_size(self):
         return self._storage.sector_size
-
-    def __enter__(self):
-        self._storage.__enter__()
-        return self
-
-    def __exit__(self, *args):
-        self._storage.__exit__(*args)

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ sitepackages = True
 usedevelop = True
 deps =
     test,bench: pytest
-    test,bench: userstorage>=0.4
+    test,bench: userstorage>=0.5.1
     py38: systemd
     test: pytest-cov
     test: pytest-timeout


### PR DESCRIPTION
Update userstorage to v0.5.1.

Set pytest.xfail as handler for missing
storage.

Currently, all tests that rely on userstorage employ
the Backend wrapper only to add a couple attributes.

With recent update, context management is natively
supported by userstorage library. On the other
hand, not all test require the Backend additional
attributes.

We can avoid using the Backend wrapper completely
for tests that do not require the attributes.
Otherwise, the Backend can just wrap the
storage from within the userstorage context (i.e.,
after the storage is setup), so we avoid the
__enter__() and __exit__() overrides.

Signed-off-by: Albert Esteve <aesteve@redhat.com>