### PR TITLE
Load ticket as the Server starts

### DIFF
--- a/test/containerized_test.py
+++ b/test/containerized_test.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import json
+import http.client as http_client
+
+from ovirt_imageio._internal import config
+from ovirt_imageio._internal import server
+from ovirt_imageio._internal.units import KiB
+
+from . import testutil
+from . import http
+
+
+TICKET_SIZE = 16 * KiB
+
+
+def test_start_with_ticket(tmpdir):
+    # Create ticket
+    image = testutil.create_tempfile(tmpdir, name="disk.raw", size=TICKET_SIZE)
+    ticket = testutil.create_ticket(size=TICKET_SIZE, url=f'file://{image}')
+    ticket_id = ticket['uuid']
+    ticket_path = tmpdir.join("file.json")
+    ticket_path.write(json.dumps(ticket))
+
+    # Start server with ticket
+    cfg = config.load("test/conf/daemon.conf")
+    srv = server.Server(cfg, ticket=ticket_path)
+    srv.start()
+    try:
+        data = b"a" * (TICKET_SIZE // 2) + b"b" * (TICKET_SIZE // 2)
+        # Test that we can upload
+        with http.RemoteClient(srv.config) as c:
+            res = c.put(f'/images/{ticket_id}', data)
+            assert res.status == http_client.OK
+        # Test that we can download and matches the uploaded data
+        with http.RemoteClient(srv.config) as c:
+            res = c.get(f'/images/{ticket_id}')
+            assert res.read() == data
+            assert res.status == http_client.OK
+    finally:
+        srv.stop()


### PR DESCRIPTION
Add a -t/--ticket option to the ovirt-imageio
server CLI, so that it can optionally load a
ticket directly as the server starts.
```
$ ovirt-imageio -c config -t path/to/ticket.json
2022-09-22 12:36:51,082 INFO    (MainThread) [server] Starting (hostname=fedora pid=3113040, version=2.4.7)                                                   
2022-09-22 12:36:51,082 DEBUG   (MainThread) [services] Creating remote.service on port 54322                                                                  
...
2022-09-22 12:36:51,087 INFO    (MainThread) [server] Initial ticket: examples/file.json
2022-09-22 12:36:51,087 INFO    (MainThread) [services] control.service listening on 'test/daemon.sock'
2022-09-22 12:36:51,087 DEBUG   (MainThread) [services] Starting remote.service 
2022-09-22 12:36:51,087 DEBUG   (remote.service) [services] remote.service started
2022-09-22 12:36:51,087 DEBUG   (MainThread) [services] Starting local.service
2022-09-22 12:36:51,087 DEBUG   (local.service) [services] local.service started
2022-09-22 12:36:51,087 DEBUG   (MainThread) [services] Starting control.service
2022-09-22 12:36:51,087 DEBUG   (control.service) [services] control.service started
2022-09-22 12:36:51,088 INFO    (MainThread) [server] Ready for requests
```
Signed-off-by: Albert Esteve <aesteve@redhat.com>