### PR TITLE
ovirt-imageio-container: tool creation and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ METADATA = ovirt_imageio/_internal/version.py Makefile
 build:
 	python3 setup.py build_ext --build-lib .
 
-check: images
+check: images container
 	tox
 
 dist: $(GENERATED)

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -32,5 +32,6 @@ fi
 
 env="$1"
 
+make container
 make storage
 tox -e reuse,flake8,test-$env,bench-$env

--- a/containers/centos-8.containerfile
+++ b/containers/centos-8.containerfile
@@ -18,6 +18,7 @@ RUN echo v1 \
         libguestfs-tools-c \
         make \
         openssl \
+        podman \
         python3-devel \
         python3-ovirt-engine-sdk4 \
         python3-pip \

--- a/containers/centos-9.containerfile
+++ b/containers/centos-9.containerfile
@@ -16,6 +16,7 @@ RUN echo v1 \
         libguestfs-tools-c \
         make \
         openssl \
+        podman \
         python3-devel \
         python3-ovirt-engine-sdk4 \
         python3-pip \

--- a/containers/fedora-35.containerfile
+++ b/containers/fedora-35.containerfile
@@ -18,6 +18,7 @@ RUN echo v1 \
         make \
         openssl \
         openssl-devel \
+        podman \
         python3-devel \
         python3-pip \
         python3-setuptools \

--- a/containers/fedora-36.containerfile
+++ b/containers/fedora-36.containerfile
@@ -18,6 +18,7 @@ RUN echo v1 \
         make \
         openssl \
         openssl-devel \
+        podman \
         python3-devel \
         python3-pip \
         python3-setuptools \

--- a/test/containerized_test.py
+++ b/test/containerized_test.py
@@ -1,42 +1,111 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-import json
+import logging
+import os
+import stat
+import subprocess
+import time
+import shutil
+from collections import namedtuple
 import http.client as http_client
 
-from ovirt_imageio._internal import config
-from ovirt_imageio._internal import server
+import pytest
+
 from ovirt_imageio._internal.units import KiB
 
 from . import testutil
 from . import http
 
 
-TICKET_SIZE = 16 * KiB
+log = logging.getLogger("test")
+
+PODMAN_CMD = "podman"
+
+FILE_SIZE = 16 * KiB
+TICKET_ID = "test"
+CONTAINER_IMG_PATH = "/images/disk.raw"
+CONTAINER_IMAGE = "localhost/ovirt-imageio:latest"
+
+Server = namedtuple("Server", ["host", "port"])
 
 
-def test_start_with_ticket(tmpdir):
-    # Create ticket
-    image = testutil.create_tempfile(tmpdir, name="disk.raw", size=TICKET_SIZE)
-    ticket = testutil.create_ticket(size=TICKET_SIZE, url=f'file://{image}')
-    ticket_id = ticket['uuid']
-    ticket_path = tmpdir.join("file.json")
-    ticket_path.write(json.dumps(ticket))
-
-    # Start server with ticket
-    cfg = config.load("test/conf/daemon.conf")
-    srv = server.Server(cfg, ticket=ticket_path)
-    srv.start()
+def _imageio_image_missing():
+    if shutil.which(PODMAN_CMD) is None:
+        return True
+    cmd = [PODMAN_CMD, "image", "inspect", CONTAINER_IMAGE]
     try:
-        data = b"a" * (TICKET_SIZE // 2) + b"b" * (TICKET_SIZE // 2)
-        # Test that we can upload
-        with http.RemoteClient(srv.config) as c:
-            res = c.put(f'/images/{ticket_id}', data)
-            assert res.status == http_client.OK
-        # Test that we can download and matches the uploaded data
-        with http.RemoteClient(srv.config) as c:
-            res = c.get(f'/images/{ticket_id}')
-            assert res.read() == data
-            assert res.status == http_client.OK
-    finally:
-        srv.stop()
+        return subprocess.check_call(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        return True
+
+
+@pytest.fixture
+def tmp_image(tmpdir):
+    image_path = tmpdir.mkdir("image")
+    image = testutil.create_tempfile(
+        image_path, name=os.path.basename(CONTAINER_IMG_PATH), size=FILE_SIZE)
+    os.chmod(image, stat.S_IROTH | stat.S_IWOTH)
+    return str(image)
+
+
+def _wait_for_server(host, port, timeout):
+    start = time.monotonic()
+    deadline = start + timeout
+    conn = http_client.HTTPConnection(host, port)
+    while True:
+        try:
+            conn.connect()
+        except ConnectionRefusedError:
+            now = time.monotonic()
+            if now >= deadline:
+                return False
+            time.sleep(0.25)
+        else:
+            log.debug("Waited for %.6f seconds", time.monotonic() - start)
+            return True
+
+
+@pytest.fixture
+def srv(tmp_image):
+    host = "localhost"
+    random_port = testutil.random_tcp_port()
+    cmd = [PODMAN_CMD, "run", "--rm", "-it"]
+    # Port redirect.
+    cmd.extend(("-p", f"{random_port}:80"))
+    # Image volume.
+    cmd.extend(("-v", f"{os.path.dirname(tmp_image)}"
+                      f":{os.path.dirname(CONTAINER_IMG_PATH)}:Z"))
+    cmd.append(CONTAINER_IMAGE)
+    cmd.extend(("--ticket-id", TICKET_ID))
+    cmd.append(CONTAINER_IMG_PATH)
+    # Run command.
+    srv_proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # Wait for server to start.
+    if not _wait_for_server(host, random_port, timeout=10):
+        log.error("Dumping server logs:")
+        log.warning("%s", srv_proc.stdout.read().decode("utf-8"))
+        log.error("%s", srv_proc.stderr.read().decode("utf-8"))
+        pytest.fail("Server could not start")
+    yield Server(host, random_port)
+    srv_proc.terminate()
+
+
+@pytest.mark.xfail(
+    reason="Container image not found",
+    strict=True,
+    condition=_imageio_image_missing())
+def test_containerized_server(srv):
+    data = b"a" * (FILE_SIZE // 2) + b"b" * (FILE_SIZE // 2)
+    conn = http_client.HTTPConnection(srv.host, srv.port)
+    # Test that we can upload.
+    # with http.HTTPClient(conn) as c:
+    #    res = c.put(f"/images/{TICKET_ID}", data)
+    #    assert res.status == http_client.OK
+    # Test that we can download and matches the uploaded data.
+    with http.HTTPClient(conn) as c:
+        res = c.get(f"/images/{TICKET_ID}")
+        assert res.read() == data
+        assert res.status == http_client.OK


### PR DESCRIPTION
Create a new tool to start and ease the management of
the containerized imageio.

Currently, it requires to manually create a static ticket,
handle paths, both local and in the container, and
set environment variables, all of that only to start
the imageio server.

We could have a tool that does all of that for you, on
the fly:
```
ovirt-imageio-container --port 8080 disk.img
```
It could also serve using nbd protocol without having to start
`qemu-nbd` manually, and select another ticket.
```
ovirt-imageio-container --port 8080 --backend file disk.img
```

This will also simplify testing container in the CIs.

Depends on: https://github.com/oVirt/ovirt-imageio/pull/145
Signed-off-by: Albert Esteve <aesteve@redhat.com>