### PR TITLE
server: Make systemd optional

### DIFF
--- a/examples/conf.d/daemon.conf
+++ b/examples/conf.d/daemon.conf
@@ -2,6 +2,9 @@
 #
 #    ./ovirt-imageio -c examples
 
+[daemon]
+systemd_enable = false
+
 [tls]
 key_file = test/pki/system/key.pem
 cert_file = test/pki/system/cert.pem

--- a/ovirt_imageio/_internal/config.py
+++ b/ovirt_imageio/_internal/config.py
@@ -54,6 +54,10 @@ class daemon:
     # configuration.
     group_name = "ovirtimg"
 
+    # Enable systemd integration. Must be enabled when running via the systemd
+    # daemon and disabled otherwise.
+    systemd_enable = True
+
 
 class tls:
 

--- a/ovirt_imageio/_internal/server.py
+++ b/ovirt_imageio/_internal/server.py
@@ -19,8 +19,6 @@ import signal
 import socket
 import sys
 
-import systemd.daemon
-
 from . import auth
 from . import config
 from . import errors
@@ -51,7 +49,7 @@ def main():
 
         server.start()
         try:
-            systemd.daemon.notify("READY=1")
+            notify_systemd(cfg)
             log.info("Ready for requests")
             while server.running:
                 signal.pause()
@@ -114,6 +112,13 @@ def configure_logger(cfg):
     parser = configparser.RawConfigParser()
     parser.read_dict(config.to_dict(cfg))
     logging.config.fileConfig(parser, disable_existing_loggers=False)
+
+
+def notify_systemd(cfg):
+    if cfg.daemon.systemd_enable:
+        log.debug("Notifying systemd")
+        import systemd.daemon
+        systemd.daemon.notify("READY=1")
 
 
 class Server:

--- a/test/conf.d/daemon.conf
+++ b/test/conf.d/daemon.conf
@@ -3,6 +3,9 @@
 #
 #    ./ovirt-imageio -c test
 
+[daemon]
+systemd_enable = false
+
 [tls]
 key_file = test/pki/system/key.pem
 cert_file = test/pki/system/cert.pem

--- a/test/conf/daemon.conf
+++ b/test/conf/daemon.conf
@@ -4,6 +4,7 @@
 [daemon]
 poll_interval = 0.1
 drop_privileges = false
+systemd_enable = false
 
 [tls]
 key_file = test/pki/system/key.pem

--- a/test/conf/proxy.conf
+++ b/test/conf/proxy.conf
@@ -4,6 +4,7 @@
 [daemon]
 poll_interval = 0.1
 drop_privileges = false
+systemd_enable = false
 
 [tls]
 key_file = test/pki/system/key.pem

--- a/test/conf/user-tls.conf
+++ b/test/conf/user-tls.conf
@@ -1,5 +1,8 @@
 # Drop-in configuration for testing user-defined PKI certificates.
 
+[daemon]
+systemd_enable = false
+
 [tls]
 key_file = test/pki/user/key.pem
 cert_file = test/pki/user/cert.pem


### PR DESCRIPTION
When running without systemd (e.g. in a container) we don't need to notify system. Add new configuration "daemon:systemd_enable" to allow disabling systemd integration. This removes the runtime dependency on the systemd.daemon package, simplifying deployment.

Disable systemd integration in all the test and example configurations system they never start the daemon as a systemd service.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>