### PR TITLE
Containerized imageio deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GENERATED = \
 
 METADATA = ovirt_imageio/_internal/version.py Makefile
 
-.PHONY: build check dist srpm rpm clean images clean-images storage clean-storage $(SPEC_NAME) venv
+.PHONY: build check dist container srpm rpm clean images clean-images storage clean-storage $(SPEC_NAME) venv
 
 build:
 	python3 setup.py build_ext --build-lib .
@@ -24,6 +24,11 @@ check: images
 
 dist: $(GENERATED)
 	python3 setup.py sdist --dist-dir "$(OUTDIR)"
+
+container: dist
+	cp $(OUTDIR)/ovirt-imageio-*.tar.gz container/ovirt-imageio.tar.gz
+	podman build -t ovirt-imageio container
+	rm -f container/ovirt-imageio.tar.gz
 
 srpm: dist
 	rpmbuild --define="_topdir $(RPM_TOPDIR)" \

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -15,4 +15,4 @@ RUN mkdir /etc/ovirt-imageio
 COPY --from=build /venv /venv
 COPY conf.d /etc/ovirt-imageio/conf.d
 EXPOSE 80/tcp
-CMD /venv/bin/ovirt-imageio
+CMD /venv/bin/ovirt-imageio -t ${TICKET_PATH}

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,18 @@
+# Build stage
+
+FROM alpine AS build
+RUN apk add --no-cache --update build-base linux-headers python3 python3-dev py3-pip
+WORKDIR /build
+COPY ovirt-imageio.tar.gz .
+RUN python3 -m venv /venv
+RUN /venv/bin/pip install ovirt-imageio.tar.gz
+
+# Final stage
+
+FROM alpine
+RUN apk add python3
+RUN mkdir /etc/ovirt-imageio
+COPY --from=build /venv /venv
+COPY conf.d /etc/ovirt-imageio/conf.d
+EXPOSE 80/tcp
+CMD /venv/bin/ovirt-imageio

--- a/container/conf.d/daemon.conf
+++ b/container/conf.d/daemon.conf
@@ -1,0 +1,22 @@
+[daemon]
+systemd_enable = false
+drop_privileges = false
+
+[tls]
+enable = false
+
+[control]
+enable = false
+
+[remote]
+port = 80
+
+[local]
+enable = false
+
+[handlers]
+keys = stderr
+
+[logger_root]
+level = INFO
+handlers = stderr


### PR DESCRIPTION
Start a container image for running imageio and container.

Using a container, the user will run an image transfer pod for every
transfer, exposing the pod for remote access, and connecting the
relevant storage the pod. When the transfer is done, the user will
unexpose the pod and terminate it.

In this mode the imageio server will serve one ticket, injected into the
pod when starting the pod, instead of adding a ticket using the control
service.

Signed-off-by: Nir Soffer [nsoffer@redhat.com](mailto:nsoffer@redhat.com)
Signed-off-by: Albert Esteve [aesteve@redhat.com](mailto:aesteve@redhat.com)