### PR TITLE
Make control service optional

### DIFF
--- a/ovirt_imageio/_internal/config.py
+++ b/ovirt_imageio/_internal/config.py
@@ -139,6 +139,9 @@ class local:
 
 class control:
 
+    # Enable control service.
+    enable = True
+
     # Transport be used to communicate with control service socket.
     # Can be either "tcp" or "unix". If "unix" is used, communication will
     # be done over UNIX socket which path is specified in "socket" option.


### PR DESCRIPTION
When running in a container we will load the ticket using --ticket option so we don't need the control service.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>