### PR TITLE
Fix push to quay.io

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,7 +10,7 @@ on:
   schedule:
     - cron:  '0 0 * * 1'
 env:
-  IMAGE_REGISTRY: quay.io
+  IMAGE_REGISTRY: quay.io/ovirt
   can_push: ${{ github.repository_owner == 'oVirt' }}
 jobs:
   test-containers:
@@ -32,7 +32,7 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ovirt/imageio-test-${{ matrix.distro }}
+          image: imageio-test-${{ matrix.distro }}
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ovirt/ovirt-imageio
+          image: ovirt-imageio
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
Based on the examples[1] the quay.io username should be part of the `registry` value. Hopefully this will find the image built in the build step `localhost/image` and will push it to `quay.io/ovirt/image`.

[1] https://github.com/redhat-actions/push-to-registry#examples

Signed-off-by: Nir Soffer <nsoffer@redhat.com>