### PR TITLE
backend.http: support non-secure connections

### DIFF
--- a/ovirt_imageio/_internal/backends/__init__.py
+++ b/ovirt_imageio/_internal/backends/__init__.py
@@ -14,6 +14,7 @@ from . import nbd
 
 _modules = {
     "file": file,
+    "http": http,
     "https": http,
     "nbd": nbd,
 }

--- a/ovirt_imageio/_internal/backends/__init__.py
+++ b/ovirt_imageio/_internal/backends/__init__.py
@@ -14,8 +14,8 @@ from . import nbd
 
 _modules = {
     "file": file,
-    "nbd": nbd,
     "https": http,
+    "nbd": nbd,
 }
 
 


### PR DESCRIPTION
Support HTTP connections without the secure
extension in the http backend. This way, the
backend can handle both http and https url
schemes from the http client.

If the url is non-secure, then we create
an http.HTTPConnection instead, and simply skip
creating the TLS context.

Signed-off-by: Albert Esteve <aesteve@redhat.com>
