### PR TITLE
container: serve image with nbd

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -13,9 +13,10 @@ RUN /venv/bin/pip install ovirt-imageio.tar.gz
 # Final stage
 
 FROM alpine
-RUN apk add python3
+RUN apk add python3 qemu-img
 RUN mkdir /etc/ovirt-imageio
 COPY --from=build /venv /venv
 COPY conf.d /etc/ovirt-imageio/conf.d
+COPY app /app
 EXPOSE 80/tcp
-CMD /venv/bin/ovirt-imageio -t ${TICKET_PATH}
+ENTRYPOINT [ "/app/entrypoint.py" ]

--- a/container/app/entrypoint.py
+++ b/container/app/entrypoint.py
@@ -1,0 +1,67 @@
+#!/venv/bin/python3
+#
+# SPDX-FileCopyrightText: Red Hat, Inc.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import argparse
+import json
+import os
+import subprocess
+
+from ovirt_imageio._internal import qemu_img
+from ovirt_imageio._internal import qemu_nbd
+from ovirt_imageio._internal import nbd
+from ovirt_imageio._internal import util
+
+TICKET_PATH = "/app/ticket.json"
+OVIRT_IMAGEIO = "/venv/bin/ovirt-imageio"
+
+
+def main():
+    args = _parse_args()
+    image_info = qemu_img.info(args.image)
+    with util.tmp_dir("imageio-") as base:
+        socket_path = os.path.join(base, "sock")
+
+        ticket_info = _generate_ticket(
+            args.ticket_id, socket_path, image_info["virtual-size"])
+        with open(TICKET_PATH, "w") as f:
+            f.write(json.dumps(ticket_info))
+
+        sock = nbd.UnixAddress(socket_path)
+        with qemu_nbd.run(args.image, image_info["format"], sock):
+            subprocess.run(
+                [OVIRT_IMAGEIO, "--ticket", TICKET_PATH], check=True)
+
+
+def _generate_ticket(uuid, socket, size):
+    ticket_info = {}
+    ticket_info["uuid"] = uuid
+    ticket_info["url"] = f"nbd:unix:{socket}"
+    ticket_info["size"] = size
+    ticket_info["timeout"] = 3000
+    ticket_info["inactivity_timeout"] = 300
+    ticket_info["ops"] = ["read"]
+    return ticket_info
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="ovirt-imageio")
+    parser.add_argument("image", help="Path to image.")
+    parser.add_argument(
+        "--ticket-id",
+        help="Optional. Set the ID of the ticket. It is recommended "
+        "to use with random string for better security. "
+        "Defaults to the image filename.")
+
+    args = parser.parse_args()
+    # Ticket ID defaults to image filename if not set.
+    args.ticket_id = args.ticket_id or os.path.basename(args.image)
+    return args
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Interrupted, shutting down")

--- a/ovirt_imageio/_internal/util.py
+++ b/ovirt_imageio/_internal/util.py
@@ -5,7 +5,11 @@ import collections
 import io
 import mmap
 import os
+import shutil
+import tempfile
 import threading
+
+from contextlib import contextmanager
 
 from .units import KiB
 
@@ -106,6 +110,15 @@ def ensure_text(s, encoding='utf-8', errors='strict'):
         return s
     else:
         raise TypeError("not expecting type '%s'" % type(s))
+
+
+@contextmanager
+def tmp_dir(prefix):
+    path = tempfile.mkdtemp(prefix=prefix)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
 
 
 class UnbufferedStream:

--- a/ovirt_imageio/client/_api.py
+++ b/ovirt_imageio/client/_api.py
@@ -8,10 +8,8 @@ api - imageio public client API.
 import json
 import logging
 import os
-import shutil
 import signal
 import tarfile
-import tempfile
 
 from contextlib import contextmanager
 from urllib.parse import urlparse
@@ -19,6 +17,7 @@ from urllib.parse import urlparse
 from .. _internal import blkhash
 from .. _internal import qemu_img
 from .. _internal import qemu_nbd
+from .. _internal import util
 from .. _internal.backends import http, nbd
 from .. _internal.handlers import checksum as _checksum
 from .. _internal.nbd import UnixAddress
@@ -489,7 +488,7 @@ def _open_nbd(filename, fmt, read_only=False, shared=1, bitmap=None,
     """
     Open nbd backend.
     """
-    with _tmp_dir("imageio-") as base:
+    with util.tmp_dir("imageio-") as base:
         sock = UnixAddress(os.path.join(base, "sock"))
 
         # If the applicatiion is handling signals, block SIGINT in qemu-nbd for
@@ -525,12 +524,3 @@ def _open_http(transfer_url, mode, cafile=None, secure=True, proxy_url=None):
                   transfer_url, e, proxy_url)
         url = urlparse(proxy_url)
         return http.open(url, mode, cafile=cafile, secure=secure)
-
-
-@contextmanager
-def _tmp_dir(prefix):
-    path = tempfile.mkdtemp(prefix=prefix)
-    try:
-        yield path
-    finally:
-        shutil.rmtree(path)


### PR DESCRIPTION
Include qemu-nbd in the container to make it
easier for users to use the containerized imageio
server.

The container now runs with a script as an
ENTRYPOINT. The script runs as a program that
can receive additional command line parameters.
The script is basically a launcher for the two
main services involved:
- qemu-nbd serving the image
- ovirt-imageio exposing the image through http

This commit removes support for file ticket, only
nbd tickets are implicitely used. This is better,
as nbd does much of the hard work for us, so will
perform better.

Users will not have to worry about
the ticket anyway, the ticket is also generated
automatically, so no need to mount the ticket
inside the container, or give an environment
variable. Users can set the ticket ID in the
command line, or use the file name as default.

Example session:
```
$ mkdir /var/tmp/images
$ qemu-img create -f raw /var/tmp/images/disk.raw 6g

$ podman run \
        --interactive \
        --tty \
        --rm \
        --publish 8080:80 \
        --volume /var/tmp/images:/var/tmp:Z \
        localhost/ovirt-imageio:latest /var/tmp/disk.raw
2022-10-20 14:46:08,953 INFO    (MainThread) [server] Starting (hostname=1594cc8a121b pid=8, version=2.4.7)
2022-10-20 14:46:08,970 INFO    (MainThread) [services] remote.service listening on ('::', 80)
2022-10-20 14:46:08,970 INFO    (MainThread) [server] Initial ticket: /ticket.json
2022-10-20 14:46:08,971 INFO    (MainThread) [server] Ready for requests
...
2022-10-26 12:07:00,155 INFO    (MainThread) [server] Received signal 2, shutting down

$ examples/imageio-client download -f raw http://localhost:8080/images/disk.raw download.raw
[ 100%  ] 6.00 GiB, 0.10 s, 57.23 GiB/s
```
Signed-off-by: Albert Esteve <aesteve@redhat.com>