### PR TITLE
Support Ticket with name

### DIFF
--- a/ovirt_imageio/_internal/auth.py
+++ b/ovirt_imageio/_internal/auth.py
@@ -21,7 +21,10 @@ class Ticket:
             raise errors.InvalidTicket(
                 "Invalid ticket: %r, expecting a dict" % ticket_dict)
 
-        self._uuid = _required(ticket_dict, "uuid", str)
+        self._uuid = _optional(ticket_dict, "uuid", str)
+        if self._uuid is None:
+            # Require 'name' and leave 'uuid' as a legacy key.
+            self._uuid = _required(ticket_dict, "name", str)
         self._size = _required(ticket_dict, "size", int)
         self._ops = _required(ticket_dict, "ops", list)
 

--- a/test/auth_test.py
+++ b/test/auth_test.py
@@ -384,6 +384,7 @@ def test_invalid_argument(arg, cfg):
 
 @pytest.mark.parametrize("kw", [
     {"uuid": 1},
+    {"name": 1},
     {"size": "not an int"},
     {"ops": "not a list"},
     {"timeout": "not an int"},
@@ -407,6 +408,18 @@ def test_inactivity_timeout_unset(cfg):
 def test_sparse_unset(cfg):
     ticket = Ticket(testutil.create_ticket(), cfg)
     assert not ticket.sparse
+
+
+def test_uuid(cfg):
+    ticket_uuid = "uuid"
+    ticket = Ticket(testutil.create_ticket(uuid=ticket_uuid), cfg)
+    assert ticket.uuid == ticket_uuid
+
+
+def test_name(cfg):
+    ticket_name = "name"
+    ticket = Ticket(testutil.create_ticket(name=ticket_name), cfg)
+    assert ticket.uuid == ticket_name
 
 
 def test_sparse(cfg):
@@ -724,6 +737,15 @@ def test_authorizer_add(cfg):
 
     ticket = auth.get(ticket_info["uuid"])
     assert ticket.uuid == ticket_info["uuid"]
+
+
+def test_authorizer_add_name(cfg):
+    auth = Authorizer(cfg)
+    ticket_info = testutil.create_ticket(name="name", ops=["read"])
+    auth.add(ticket_info)
+
+    ticket = auth.get(ticket_info["name"])
+    assert ticket.uuid == ticket_info["name"]
 
 
 def test_authorizer_remove_unused(cfg):

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -32,17 +32,20 @@ def random_tcp_port():
         return port
 
 
-def create_ticket(uuid=None, ops=None, timeout=300, size=2**64,
+def create_ticket(uuid=None, name=None, ops=None, timeout=300, size=2**64,
                   url="file:///tmp/foo.img", transfer_id=None, filename=None,
                   sparse=None, dirty=None, inactivity_timeout=120):
     d = {
-        "uuid": uuid or str(uuid4()),
         "timeout": timeout,
         "ops": ["read", "write"] if ops is None else ops,
         "size": size,
         "url": url,
         "transfer_id": transfer_id or str(uuid4()),
     }
+    if name is not None:
+        d["name"] = name
+    else:
+        d["uuid"] = uuid or str(uuid4())
     if filename is not None:
         d["filename"] = filename
     if sparse is not None:


### PR DESCRIPTION
Current "uuid" key in the ticket dictionary
is misleading, as it does not necessarily
need to be an uuid, it is just a string to
identify the ticket.

We need to keep it for back-compatibility,
as other projects use the "uuid" key and
there is much code involved.

We can, instead, support "name" key in the
ticket dictionary, as an alternative to
"uuid". So we leave the "uuid" as a legacy
key, but still supported. In the ticket,
if not "uuid" nor "name" are set, we will
raise asking for "name", as is the new
key. If both are set, "uuid" prevails.

Signed-off-by: Albert Esteve <aesteve@redhat.com>