### PR TITLE
client: add --insecure option

### DIFF
--- a/ovirt_imageio/client/_download.py
+++ b/ovirt_imageio/client/_download.py
@@ -52,6 +52,7 @@ def download_disk(args):
                     args.filename,
                     args.cafile,
                     fmt=args.format,
+                    secure=args.secure,
                     proxy_url=transfer.proxy_url,
                     max_workers=args.max_workers,
                     buffer_size=args.buffer_size,

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -46,12 +46,13 @@ log_level = Choices("log_level", ("debug", "info", "warning", "error"))
 
 
 class Option(
-        namedtuple("Option", "name,args,config,required,type,default,help")):
+        namedtuple(
+            "Option", "name,args,config,required,action,type,default,help")):
 
     __slots__ = ()
 
     def __new__(cls, name=None, args=(), config=False, required=False,
-                type=str, default=None, help=None):
+                action=None, type=str, default=None, help=None):
         """
         Arguments:
             name (str): Option name use in config file or parsed arguments.
@@ -61,6 +62,8 @@ class Option(
             required (bool): If True this option is required and parsing
                 arguments will fail if it is not specified in the command line
                 or config file.
+            action (Union[argparse.Action, str]): Specify how an argument
+                should be handled. Defaults to 'store' action.
             type (callable): Callable converting the command line argument or
                 config value to the wanted type. Must raise ValueError if the
                 value is invalid and cannot be converted.
@@ -69,7 +72,20 @@ class Option(
             help (str): Help message to show in the online help.
         """
         return tuple.__new__(
-            cls, (name, args, config, required, type, default, help))
+            cls, (name, args, config, required, action, type, default, help))
+
+    @property
+    def kwargs(self):
+        option_kwargs = {
+            "dest": self.name,
+            "default": None,
+            "help": self.help,
+        }
+        if self.action:
+            option_kwargs["action"] = self.action
+        else:
+            option_kwargs["type"] = self.type
+        return option_kwargs
 
 
 class Parser:
@@ -115,6 +131,14 @@ class Parser:
                   "from the specified config section"),
         ),
         Option(
+            name="secure",
+            args=["--insecure"],
+            action="store_false",
+            default=True,
+            help=("Do not verify server certificates and host name (not "
+                  "recommened).")
+        ),
+        Option(
             name="disk_timeout",
             config=True,
             type=int,
@@ -155,11 +179,7 @@ class Parser:
             if not option.args:
                 continue
 
-            cmd.add_argument(
-                *option.args,
-                dest=option.name,
-                type=option.type,
-                help=option.help)
+            cmd.add_argument(*option.args, **option.kwargs)
 
         if transfer_options:
             size = Size(minimum=1, default=MAX_WORKERS, maximum=8)

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -20,6 +20,9 @@ import uuid
 
 
 ADD_DISK_TIMEOUT = 120
+# Possible boolean values in the configuration.
+BOOLEAN_VALUES = {'1': True, 'yes': True, 'true': True, 'on': True,
+                  '0': False, 'no': False, 'false': False, 'off': False}
 
 
 class Choices:
@@ -43,6 +46,12 @@ class Choices:
 
 
 log_level = Choices("log_level", ("debug", "info", "warning", "error"))
+
+
+def bool_string(value):
+    if value.lower() not in BOOLEAN_VALUES:
+        raise ValueError(f"Not a boolean: '{value}'")
+    return BOOLEAN_VALUES[value.lower()]
 
 
 class Option(
@@ -134,7 +143,9 @@ class Parser:
             name="secure",
             args=["--insecure"],
             action="store_false",
+            config=True,
             default=True,
+            type=bool_string,
             help=("Do not verify server certificates and host name (not "
                   "recommened).")
         ),

--- a/ovirt_imageio/client/_upload.py
+++ b/ovirt_imageio/client/_upload.py
@@ -97,6 +97,7 @@ def upload_disk(args):
                     args.cafile,
                     buffer_size=args.buffer_size,
                     progress=progress,
+                    secure=args.secure,
                     proxy_url=transfer.proxy_url,
                     max_workers=args.max_workers,
                     disk_is_zero=disk_info.is_zero)

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -154,6 +154,7 @@ def test_config_all(config):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile == "/engine.pem"
+    assert args.secure is True
     assert args.disk_timeout == 200
     assert args.log_file == "/var/log/ovirt-img/engine.log"
     assert args.log_level == "info"
@@ -184,6 +185,7 @@ def test_config_all_override(config, tmpdir):
     assert args.engine_url == "https://engine2.com"
     assert args.username == "username2"
     assert args.cafile == "/engine2.pem"
+    assert args.secure is True
     assert args.disk_timeout == 200
     assert args.log_file == "test.log"
     assert args.log_level == "debug"
@@ -204,6 +206,7 @@ def test_config_required(config, monkeypatch):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile is None
+    assert args.secure is True
     assert args.disk_timeout == 120
     assert args.log_file is None
     assert args.log_level == "warning"
@@ -226,12 +229,14 @@ def test_config_required_override(config, tmpdir):
         "-c", "required",
         "--password-file", str(password_file),
         "--cafile", "/engine2.pem",
+        "--insecure",
         "--log-file", "test.log",
         "--log-level", "debug",
     ])
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile == "/engine2.pem"
+    assert args.secure is False
     assert args.disk_timeout == 120
     assert args.log_file == "test.log"
     assert args.log_level == "debug"

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -118,6 +118,7 @@ engine_url = https://engine.com
 username = username
 password = password
 cafile = /engine.pem
+secure = False
 disk_timeout = 200
 log_file = /var/log/ovirt-img/engine.log
 log_level = info
@@ -139,11 +140,17 @@ username = username
 #username is not set
 password = password
 
-[invalid]
+[invalid_log_level]
 engine_url = https://engine.com
 username = username
 password = password
-log_level = invalid log level
+log_level = invalid value
+
+[invalid_secure]
+engine_url = https://engine.com
+username = username
+password = password
+secure = invalid value
 """)
 
 
@@ -154,7 +161,7 @@ def test_config_all(config):
     assert args.engine_url == "https://engine.com"
     assert args.username == "username"
     assert args.cafile == "/engine.pem"
-    assert args.secure is True
+    assert args.secure is False
     assert args.disk_timeout == 200
     assert args.log_file == "/var/log/ovirt-img/engine.log"
     assert args.log_level == "info"
@@ -185,7 +192,7 @@ def test_config_all_override(config, tmpdir):
     assert args.engine_url == "https://engine2.com"
     assert args.username == "username2"
     assert args.cafile == "/engine2.pem"
-    assert args.secure is True
+    assert args.secure is False
     assert args.disk_timeout == 200
     assert args.log_file == "test.log"
     assert args.log_level == "debug"
@@ -276,13 +283,17 @@ def test_config_missing_override(config):
     assert args.username == "username"
 
 
-def test_config_invalid(config, capsys):
+@pytest.mark.parametrize("name", [
+    "invalid_log_level",
+    "invalid_secure",
+])
+def test_config_invalid(config, capsys, name):
     parser = _options.Parser()
     parser.add_sub_command("test", "help", lambda x: None)
     with pytest.raises(SystemExit):
-        parser.parse(["test", "-c", "invalid"])
+        parser.parse(["test", "-c", name])
     captured = capsys.readouterr()
-    assert repr("invalid log level") in captured.err
+    assert repr("invalid value") in captured.err
 
 
 def test_config_no_section(config, capsys):


### PR DESCRIPTION
Allow insecure connections using ovirt-img through a command line option.

Fixes: #153
Signed-off-by: Albert Esteve <aesteve@redhat.com>