### PR TITLE
tox: Always disable sitepackages

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ whitelist_externals =
 
 [testenv]
 passenv = *
-sitepackages = True
 usedevelop = True
 deps =
     test,bench: pytest
@@ -32,14 +31,12 @@ commands =
     bench: pytest -m 'benchmark' -vs {posargs}
 
 [testenv:reuse]
-sitepackages = False
 deps =
     reuse
 commands =
     reuse lint
 
 [testenv:flake8]
-sitepackages = False
 deps =
     flake8==3.9
 commands =


### PR DESCRIPTION
Previously we used `sitepackages=True` to get access to the `systemd.daemon` python package, installed by `python3-systemd` package.

Since commit ffa7337ec3bf (server: Make systemd optional) we always disable systemd daemon during the tests, so this access is not needed.

Disabling access to system packages allows running the tests when `pytest` is installed on the host via the package manager. This is very helpful since some projects (e.g. `blkhash`) require the system `pytest`. Before this change I had to remove the `pytest` package before running imageio tests.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>