### PR TITLE
ovirt-img: add --output format option

### DIFF
--- a/ovirt_imageio/client/_download.py
+++ b/ovirt_imageio/client/_download.py
@@ -36,7 +36,7 @@ def register(parser):
 
 
 def download_disk(args):
-    with _ui.ProgressBar(phase="creating transfer") as pb:
+    with _ui.ProgressBar(phase="creating transfer", format=args.output) as pb:
         con = _ovirt.connect(args)
         with closing(con):
             disk = _ovirt.find_disk(con, args.disk_id)

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -46,6 +46,7 @@ class Choices:
 
 
 log_level = Choices("log_level", ("debug", "info", "warning", "error"))
+output_format = Choices("output_format", ("text",))
 
 
 def bool_string(value):
@@ -148,6 +149,14 @@ class Parser:
             type=bool_string,
             help=("Do not verify server certificates and host name (not "
                   "recommened).")
+        ),
+        Option(
+            name="output",
+            args=["-o", "--output"],
+            type=output_format,
+            default="text",
+            help="Set the format in which the output must be done "
+                 f"(choices: {output_format}), default: text).",
         ),
         Option(
             name="disk_timeout",

--- a/ovirt_imageio/client/_options.py
+++ b/ovirt_imageio/client/_options.py
@@ -46,7 +46,7 @@ class Choices:
 
 
 log_level = Choices("log_level", ("debug", "info", "warning", "error"))
-output_format = Choices("output_format", ("text",))
+output_format = Choices("output_format", ("text", "json"))
 
 
 def bool_string(value):

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import json
 import sys
 import threading
 import time
@@ -9,6 +10,7 @@ from .. _internal import util
 
 
 FORMAT_TEXT = "text"
+FORMAT_JSON = "json"
 
 DEFAULT_WIDTH = 79
 
@@ -54,8 +56,25 @@ class TextFormat(OutputFormat):
         self._write_line(line, end)
 
 
+class JsonFormat(OutputFormat):
+
+    def draw(self, elapsed, value, transferred, size=None,
+             phase=None, last=False):
+        progress = {
+            'transferred': transferred,
+            'elapsed': elapsed,
+            'description': phase or "",
+        }
+        if size is not None:
+            progress["size"] = size
+
+        line = json.dumps(progress)
+        self._write_line(line)
+
+
 OUTPUT_FORMAT = {
     FORMAT_TEXT: TextFormat,
+    FORMAT_JSON: JsonFormat,
 }
 
 

--- a/ovirt_imageio/client/_ui.py
+++ b/ovirt_imageio/client/_ui.py
@@ -8,6 +8,8 @@ import time
 from .. _internal import util
 
 
+FORMAT_TEXT = "text"
+
 DEFAULT_WIDTH = 79
 
 
@@ -52,11 +54,16 @@ class TextFormat(OutputFormat):
         self._write_line(line, end)
 
 
+OUTPUT_FORMAT = {
+    FORMAT_TEXT: TextFormat,
+}
+
+
 class ProgressBar:
 
     def __init__(self, phase=None, error_phase="command failed", size=None,
-                 output=sys.stdout, step=None, width=DEFAULT_WIDTH,
-                 now=time.monotonic):
+                 output=sys.stdout, format=FORMAT_TEXT, step=None,
+                 width=DEFAULT_WIDTH, now=time.monotonic):
         """
         Arguments:
             phase (str): short description of the current phase.
@@ -66,6 +73,7 @@ class ProgressBar:
                 creating, progress value is not displayed. The size can be set
                 later to enable progress display.
             output (fileobj): file to write progress to (default sys.stdout).
+            format (str): format in which the progress is printed.
             step (float): unused, kept for backward compatibility. The progress
                 is updated in 1 percent steps.
             width (int): width of progress bar in characters (default 79)
@@ -75,7 +83,7 @@ class ProgressBar:
         self._error_phase = error_phase
         self._size = size
         self._output = output
-        self._format = TextFormat(output=output, width=width)
+        self._format = OUTPUT_FORMAT[format](output=output, width=width)
         self._now = now
         self._lock = threading.Lock()
         self._start = self._now()

--- a/ovirt_imageio/client/_upload.py
+++ b/ovirt_imageio/client/_upload.py
@@ -68,7 +68,8 @@ def register(parser):
 
 
 def upload_disk(args):
-    with _ui.ProgressBar(phase="inspecting image") as progress:
+    with _ui.ProgressBar(
+            phase="inspecting image", format=args.output) as progress:
         disk_info = _prepare(args)
         con = _ovirt.connect(args)
         with closing(con):

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -162,6 +162,7 @@ def test_config_all(config):
     assert args.username == "username"
     assert args.cafile == "/engine.pem"
     assert args.secure is False
+    assert args.output == "text"
     assert args.disk_timeout == 200
     assert args.log_file == "/var/log/ovirt-img/engine.log"
     assert args.log_level == "info"
@@ -193,6 +194,7 @@ def test_config_all_override(config, tmpdir):
     assert args.username == "username2"
     assert args.cafile == "/engine2.pem"
     assert args.secure is False
+    assert args.output == "text"
     assert args.disk_timeout == 200
     assert args.log_file == "test.log"
     assert args.log_level == "debug"
@@ -214,6 +216,7 @@ def test_config_required(config, monkeypatch):
     assert args.username == "username"
     assert args.cafile is None
     assert args.secure is True
+    assert args.output == "text"
     assert args.disk_timeout == 120
     assert args.log_file is None
     assert args.log_level == "warning"
@@ -244,6 +247,7 @@ def test_config_required_override(config, tmpdir):
     assert args.username == "username"
     assert args.cafile == "/engine2.pem"
     assert args.secure is False
+    assert args.output == "text"
     assert args.disk_timeout == 120
     assert args.log_file == "test.log"
     assert args.log_level == "debug"
@@ -338,6 +342,35 @@ def test_transfer_options_disabled(config):
     ])
     assert not hasattr(args, 'max_workers')
     assert not hasattr(args, 'buffer_size')
+
+
+@pytest.mark.parametrize("output", [
+    "text",
+])
+def test_output_option(config, output):
+    parser = _options.Parser()
+    parser.add_sub_command("test", "help", lambda x: None)
+
+    args = parser.parse([
+        "test",
+        "-c", "all",
+        "--output", output
+    ])
+    assert args.output == output
+
+
+def test_invalid_output_option(config, capsys):
+    parser = _options.Parser()
+    parser.add_sub_command("test", "help", lambda x: None)
+
+    with pytest.raises(SystemExit):
+        parser.parse([
+            "test",
+            "-c", "all",
+            "--output", "invalid value"
+        ])
+    captured = capsys.readouterr()
+    assert repr("invalid value") in captured.err
 
 
 def test_auto_help(capsys):

--- a/test/client_options_test.py
+++ b/test/client_options_test.py
@@ -346,6 +346,7 @@ def test_transfer_options_disabled(config):
 
 @pytest.mark.parametrize("output", [
     "text",
+    "json",
 ])
 def test_output_option(config, output):
     parser = _options.Parser()


### PR DESCRIPTION
Add --output option to ovirt-img, so that
the output format for the progress is set
from the CLI.

Add json as an output option, to print
the progress in jsonlines[1] format.
A consistent machine readable format, that
can be later parsed.
```
$ ovirt-img  download-disk -c engine --output json <disk_id> download.raw
{"transferred": 0, elapsed: 0.0, "description": "setting up"}
...
{"transferred": 249561088, "size": 261095424, elapsed: 1.234567, "description": "downloading image"}
{"transferred": 256901120, "size": 261095424, elapsed: 1.345678, "description": "downloading image"}
{"transferred": 261095424, "size": 261095424, elapsed: 1.456789, "description": "finalizing transfer"}
...
```

[1] https://jsonlines.org/

Fixes: https://github.com/oVirt/ovirt-imageio/issues/154
Signed-off-by: Albert Esteve <aesteve@redhat.com>