### PR TITLE
containers: unify test image

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -32,7 +32,8 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: imageio-test-${{ matrix.distro }}
+          image: ovirt-imageio-test
+          tags: ${{ matrix.distro }}
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}
           password: ${{ secrets.QUAY_TOKEN }}

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+prefix := ovirt-imageio-test
 targets := centos-8 centos-9 fedora-35 fedora-36
 
 .PHONY: $(targets) push
@@ -8,9 +9,9 @@ targets := centos-8 centos-9 fedora-35 fedora-36
 all: $(targets)
 
 $(targets):
-	podman build -t imageio-test-$@ -f $@.containerfile .
+	podman build -t $(prefix):$@ -f $@.containerfile .
 
 push:
 	for name in $(targets); do \
-		podman push imageio-test-$$name quay.io/ovirt/imageio-test-$$name; \
+		podman push $(prefix):$$name quay.io/ovirt/$(prefix):$$name; \
 	done


### PR DESCRIPTION
Current containers Makefile builds a different
image for each distro, which then gets pushed
into a different repository of the oVirt
organization in quay.io.

Changing distros in this fashion requires
creating new repositories, doing clean up
of the older ones, and update permissions.

Pushing all images into the same repository
would allow to more streamlined updates, and
ease maintenance.

Signed-off-by: Albert Esteve <aesteve@redhat.com>