### PR TITLE
ci.yml: use new repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - distro: fedora-36
             env: py310
     container:
-      image: quay.io/ovirt/imageio-test-${{matrix.distro}}
+      image: quay.io/ovirt/ovirt-imageio-test:${{matrix.distro}}
       # Required to create loop devices.
       options: --privileged
     steps:
@@ -42,7 +42,7 @@ jobs:
         - centos-9
         - fedora-35
         - fedora-36
-    container: quay.io/ovirt/imageio-test-${{matrix.distro}}
+    container: quay.io/ovirt/ovirt-imageio-test:${{matrix.distro}}
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Use new repository (ovirt-imageio-test )in the pipelines.

Signed-off-by: Albert Esteve <aesteve@redhat.com>