### PR TITLE
Remove docs team ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,5 +8,5 @@
 *               @nirs @aesteve-rh
 
 # Documentation owners
-docs/           @nirs @aesteve-rh @oVirt/ovirt-documentation
-README.md       @nirs @aesteve-rh @oVirt/ovirt-documentation
+docs/           @nirs @aesteve-rh
+README.md       @nirs @aesteve-rh


### PR DESCRIPTION
This does not work with github since docs team does not have write access, and we never got any contribution anyway. We can ask manually for review if needed.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>