### PR TITLE
Switch from Python 3.8 to 3.9 on EL8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - distro: centos-8
             env: py36
           - distro: centos-8
-            env: py38
+            env: py39
           - distro: centos-9
             env: py39
           - distro: fedora-36

--- a/containers/centos-8.containerfile
+++ b/containers/centos-8.containerfile
@@ -23,10 +23,6 @@ RUN echo v1 \
         python3-pip \
         python3-setuptools \
         python3-systemd \
-        python38-devel \
-        python38-ovirt-engine-sdk4 \
-        python38-pip \
-        python38-setuptools \
         python39-devel \
         python39-ovirt-engine-sdk4 \
         python39-pip \

--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -16,14 +16,14 @@ Source0:   https://github.com/oVirt/%{name}/releases/download/v%{version}/%{name
 %global admin_confdir %{_sysconfdir}/%{name}
 %global vendor_confdir %{_prefix}/lib/%{name}
 
-# We need to have Python 3.8 support of imageio client for oVirt Ansible
-# Collection running with ansible-core-2.12, which uses non-standard Python 3.8
+# We need to have Python 3.9 support of imageio client for oVirt Ansible
+# Collection running with ansible-core-2.13, which uses non-standard Python 3.9
 # on EL8 platform
 %if "%{?rhel}" == "8"
-%global with_python38 1
+%global with_python39 1
 %undefine __brp_mangle_shebangs
 %else
-%global with_python38 0
+%global with_python39 0
 %endif
 
 %description
@@ -33,9 +33,9 @@ Transfer disk images on oVirt system.
 %setup -q
 
 %build
-%if %{with_python38}
-%define python3_pkgversion 38
-%define __python3 /usr/bin/python3.8
+%if %{with_python39}
+%define python3_pkgversion 39
+%define __python3 /usr/bin/python3.9
 %py3_build
 %define python3_pkgversion 3
 %define __python3 /usr/bin/python3
@@ -44,9 +44,9 @@ Transfer disk images on oVirt system.
 %py3_build
 
 %install
-%if %{with_python38}
-%define python3_pkgversion 38
-%define __python3 /usr/bin/python3.8
+%if %{with_python39}
+%define python3_pkgversion 39
+%define __python3 /usr/bin/python3.9
 %py3_install
 %define python3_pkgversion 3
 %define __python3 /usr/bin/python3
@@ -175,22 +175,22 @@ if systemctl is-active ovirt-imageio-daemon.service >/dev/null; then
     systemctl stop ovirt-imageio-daemon.service
 fi
 
-%if %{with_python38}
-%define python3_pkgversion 38
-%define __python3 /usr/bin/python3.8
+%if %{with_python39}
+%define python3_pkgversion 39
+%define __python3 /usr/bin/python3.9
 
-%package -n python38-%{name}-common
+%package -n python39-%{name}-common
 Summary:   oVirt imageio common resources
 
 BuildRequires: gcc
-BuildRequires: python38-devel
+BuildRequires: python39-devel
 
-Requires:  python38
+Requires:  python39
 
-%description -n python38-%{name}-common
+%description -n python39-%{name}-common
 Common resources used by oVirt imageio server and client
 
-%files -n python38-%{name}-common
+%files -n python39-%{name}-common
 %license LICENSES/GPL-2.0-or-later.txt
 %{python3_sitearch}/%{srcname}
 %{python3_sitearch}/%{srcname}-*.egg-info
@@ -198,10 +198,10 @@ Common resources used by oVirt imageio server and client
 %exclude %{python3_sitearch}/%{srcname}/admin
 
 
-%package -n python38-%{name}-client
+%package -n python39-%{name}-client
 Summary:   oVirt imageio client library
 
-Requires:  python38-%{name}-common = %{version}-%{release}
+Requires:  python39-%{name}-common = %{version}-%{release}
 
 %if 0%{?rhel}
 # RHEL 8.4 version. Some features require qemu-nbd 5.2.0 and are disabled when
@@ -212,10 +212,10 @@ Requires:  qemu-img >= 15:4.2.0
 Requires:  qemu-img
 %endif
 
-%description -n python38-%{name}-client
+%description -n python39-%{name}-client
 Python client library for accessing imageio server on oVirt hosts.
 
-%files -n python38-%{name}-client
+%files -n python39-%{name}-client
 %{python3_sitearch}/%{srcname}/client
 
 %endif

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = reuse,flake8,test-{py36,py38,py39,py310,py311},bench-{py36,py38,py39,py310,py311}
+envlist = reuse,flake8,test-{py36,py39,py310,py311},bench-{py36,py39,py310,py311}
 skip_missing_interpreters = True
 whitelist_externals =
     ip
@@ -18,7 +18,6 @@ usedevelop = True
 deps =
     test,bench: pytest
     test,bench: userstorage>=0.5.1
-    py38: systemd
     test: pytest-cov
     test: pytest-timeout
 commands_pre =


### PR DESCRIPTION
Switch from Python 3.8 to 3.9 on EL8 to be able to support
ansible-core-2.13

Signed-off-by: Martin Perina <mperina@redhat.com>
