### PR TITLE
Support block devices in qemu_nbd

### DIFF
--- a/ovirt_imageio/_internal/qemu_nbd.py
+++ b/ovirt_imageio/_internal/qemu_nbd.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import signal
+import stat
 import subprocess
 import urllib.parse
 
@@ -147,7 +148,8 @@ class Server:
         # Build a 'json:{...}' filename allowing control all aspects of the
         # image.
 
-        file = {"driver": "file", "filename": self.image}
+        driver = "host_device" if self._is_block_device() else "file"
+        file = {"driver": driver, "filename": self.image}
 
         if self.offset is not None or self.size is not None:
             # Exposing a range in a raw file.
@@ -237,6 +239,9 @@ class Server:
         else:
             os.close(fd)
             return True
+
+    def _is_block_device(self):
+        return stat.S_ISBLK(os.stat(self.image).st_mode)
 
     def _preexec_fn(self):
         """

--- a/storage.py
+++ b/storage.py
@@ -94,4 +94,20 @@ BACKENDS = {
         )
     ),
 
+    "block-512": LoopDevice(
+        base_dir=BASE_DIR,
+        name="block-512",
+        size=GiB,
+        sector_size=512,
+        required=False,
+    ),
+
+    "block-4k": LoopDevice(
+        base_dir=BASE_DIR,
+        name="block-4k",
+        size=GiB,
+        sector_size=4096,
+        required=False,
+    ),
+
 }

--- a/test/qemu_nbd_test.py
+++ b/test/qemu_nbd_test.py
@@ -482,7 +482,6 @@ def test_block_signals(tmpdir):
         assert s.wait(0.2) is not None
 
 
-@pytest.mark.xfail(reason="block devices not supported yet")
 @pytest.mark.parametrize("fmt", ["raw", "qcow2"])
 def test_block_device(tmpdir, user_block, fmt):
     qemu_img.create(user_block.path, fmt, size=1024**3)


### PR DESCRIPTION
Add support for block devices in qemu_nbd module. This enables serving block devices
with the ovirt-imageio container and writing to block devices in the ovirt-img tool.

Based on #167, adding basic tests.