### PR TITLE
Add Python 3.9 support to CS8 container

### DIFF
--- a/containers/centos-8.containerfile
+++ b/containers/centos-8.containerfile
@@ -27,6 +27,10 @@ RUN echo v1 \
         python38-ovirt-engine-sdk4 \
         python38-pip \
         python38-setuptools \
+        python39-devel \
+        python39-ovirt-engine-sdk4 \
+        python39-pip \
+        python39-setuptools \
         qemu-img \
         qemu-kvm \
         rpm-build \


### PR DESCRIPTION
Adds Python 3.9 support to CS8 container in order to prepare to support
the project in ansible-core 2.13, which uses Python 3.9

Signed-off-by: Martin Perina <mperina@redhat.com>
