### PR TITLE
containers: create venv for tests

### DIFF
--- a/containers/centos-8.containerfile
+++ b/containers/centos-8.containerfile
@@ -40,4 +40,5 @@ RUN echo v1 \
 # Developemnt tools.
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt

--- a/containers/centos-9.containerfile
+++ b/containers/centos-9.containerfile
@@ -32,5 +32,6 @@ RUN echo v1 \
 
 # Developemnt tools.
 COPY requirements.txt requirements.txt
-RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt
+RUN python3 -m pip install --upgrade --ignore-installed pip \
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt

--- a/containers/fedora-36.containerfile
+++ b/containers/fedora-36.containerfile
@@ -35,5 +35,6 @@ RUN echo v1 \
 # Developemnt tools.
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt \
-    && python3 -m pip install ovirt-engine-sdk-python
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt \
+    && /venv/bin/python3 -m pip install ovirt-engine-sdk-python

--- a/containers/fedora-37.containerfile
+++ b/containers/fedora-37.containerfile
@@ -35,5 +35,6 @@ RUN echo v1 \
 # Developemnt tools.
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt \
-    && python3 -m pip install ovirt-engine-sdk-python
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt \
+    && /venv/bin/python3 -m pip install ovirt-engine-sdk-python

--- a/containers/fedora-38.containerfile
+++ b/containers/fedora-38.containerfile
@@ -36,5 +36,6 @@ RUN echo v1 \
 # Developemnt tools.
 COPY requirements.txt requirements.txt
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install --requirement requirements.txt \
-    && python3 -m pip install ovirt-engine-sdk-python
+    && python3 -m venv /venv \
+    && /venv/bin/python3 -m pip install --requirement requirements.txt \
+    && /venv/bin/python3 -m pip install ovirt-engine-sdk-python


### PR DESCRIPTION
In test containers, create a
new venv [1] at /venv instead of installing
the required packages directly in the
root environment. Installing packages in
the root environment is strongly discouraged,
as it can run into conflicts with the system
package manager.

[1] - https://pip.pypa.io/warnings/venv

Signed-off-by: Albert Esteve <aesteve@redhat.com>