### PR TITLE
ci test: activate venv before tests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -32,5 +32,8 @@ fi
 
 env="$1"
 
+# Activate the tests venv
+source /venv/bin/activate
+
 make storage
 tox -e reuse,flake8,test-$env,bench-$env

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,8 @@ deps =
     test: pytest-cov
     test: pytest-timeout
 commands_pre =
-    # Build ioutil for both current python (e.g. 3.8) and platform python (e.g. 3.6)
+    # Build ioutil for current python (e.g. 3.8)
     python setup.py build_ext --build-lib .
-    /usr/bin/python3 setup.py build_ext --build-lib .
     python -c 'from test import testutil; print("ipv6 supported: %s" % testutil.ipv6_enabled())'
 commands =
     test: pytest -m 'not benchmark' --cov=ovirt_imageio --durations=10 {posargs}


### PR DESCRIPTION
Activate containers venv before running
tests in the pipeline.

Signed-off-by: Albert Esteve <aesteve@redhat.com>