### PR TITLE
setup: add python 3.11 clasifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: System :: Archiving :: Backup",
         "Topic :: Utilities",
     ],


### PR DESCRIPTION
Since we are already testing Python 3.11
in the pipelines, we can add the 3.11 clasifier
to the setup.py file.

Signed-off-by: Albert Esteve <aesteve@redhat.com>