### PR TITLE
Override the python3 executable during build

### DIFF
--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -56,7 +56,7 @@ Transfer disk images on oVirt system.
 %define __python3 /usr/bin/python3
 %endif
 
-%py3_build
+%py3_build "--executable=%{quote:/usr/bin/python3 -s}"
 
 %install
 %if %{with_python39}


### PR DESCRIPTION
The python3 macros run the python3 setup.py with the python3 executable [1]. 
This executable does change all shebangs in all executable files.
When we override it to the default system, python the shebang the imageio shebang will not change.
[1] https://src.fedoraproject.org/rpms/python-rpm-macros/blob/rawhide/f/macros.python3#_31