### PR TITLE
Override the python3 executable during build v2

### DIFF
--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -56,7 +56,7 @@ Transfer disk images on oVirt system.
 %define __python3 /usr/bin/python3
 %endif
 
-%py3_build
+%py3_build "--executable=%{quote:/usr/bin/python3 -s}"
 
 %install
 %if %{with_python39}

--- a/ovirt-imageio.spec.in
+++ b/ovirt-imageio.spec.in
@@ -41,44 +41,40 @@ Transfer disk images on oVirt system.
 %setup -q
 
 %build
-
-%define python3_pkgversion 3
-%define __python3 /usr/bin/python3
-%py3_build
-
 %if %{with_python39}
 %define python3_pkgversion 39
 %define __python3 /usr/bin/python3.9
 %py3_build
+%define python3_pkgversion 3
+%define __python3 /usr/bin/python3
 %endif
 %if %{with_python311}
 %define python3_pkgversion 3.11
 %define __python3 /usr/bin/python3.11
 %py3_build
-%endif
-
 %define python3_pkgversion 3
 %define __python3 /usr/bin/python3
+%endif
+
+%py3_build
 
 %install
-
-%define python3_pkgversion 3
-%define __python3 /usr/bin/python3
-%py3_install
-
 %if %{with_python39}
 %define python3_pkgversion 39
 %define __python3 /usr/bin/python3.9
 %py3_install
+%define python3_pkgversion 3
+%define __python3 /usr/bin/python3
 %endif
 %if %{with_python311}
 %define python3_pkgversion 3.11
 %define __python3 /usr/bin/python3.11
 %py3_install
-%endif
-
 %define python3_pkgversion 3
 %define __python3 /usr/bin/python3
+%endif
+
+%py3_install
 
 install -D -m 0755 --directory %{buildroot}%{logdir}
 # Create a dummy log file to make rpm happy during build


### PR DESCRIPTION
The python3 macros run the python3 setup.py with the python3 executable [1].
This executable does change all shebangs in all executable files.
When we override it to the default system, python the shebang the imageio shebang will not change.
[1] https://src.fedoraproject.org/rpms/python-rpm-macros/blob/rawhide/f/macros.python3#_31