### PR TITLE
Fix ovirt-imageioctl without arguments

### DIFF
--- a/ovirt_imageio/admin/tool.py
+++ b/ovirt_imageio/admin/tool.py
@@ -16,6 +16,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Control the ovirt-imageio service")
 
+    parser.set_defaults(command=None)
     commands = parser.add_subparsers(title="commands")
 
     add_cmd = add_command(
@@ -76,6 +77,10 @@ def main():
         command=stop_profile)
 
     args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        sys.exit(0)
+
     try:
         args.command(args)
     except admin.Error as e:


### PR DESCRIPTION
In the same way we do in ovirt-img - running without arguments is the same as -h, --help.

Example run:

    $ ./ovirt-imageioctl
    usage: ovirt-imageioctl [-h] {add-ticket,show-ticket,mod-ticket,del-ticket,start-profile,stop-profile} ...

    Control the ovirt-imageio service

    options:
      -h, --help            show this help message and exit

    commands:
      {add-ticket,show-ticket,mod-ticket,del-ticket,start-profile,stop-profile}
        add-ticket          Add a ticket.
        show-ticket         Show a ticket status.
        mod-ticket          Modify a ticket.
        del-ticket          Delete a ticket.
        start-profile       Start server profiling
        stop-profile        Stop server profiling

Reported in:
https://github.com/oVirt/ovirt-imageio/pull/194#issuecomment-1463404284