### PR TITLE
containers: remove python3.11-pip from c8s

### DIFF
--- a/containers/centos-8.containerfile
+++ b/containers/centos-8.containerfile
@@ -26,7 +26,8 @@ RUN echo v1 \
         python3.11-devel \
         python3.11-setuptools \
         python3.11-ovirt-engine-sdk4 \
-        python3.11-pip \
+        # Missing from c8s AppStream
+        # python3.11-pip \
         qemu-img \
         qemu-kvm \
         rpm-build \


### PR DESCRIPTION
Currently the package is missing from c8s AppStream [1]. We can remove it for now.

[1] https://issues.redhat.com/browse/CS-1502

Fixes: 8e4957e