### PR TITLE
Attribute error during timeout cancelling transfer

### DIFF
--- a/ovirt_imageio/_internal/auth.py
+++ b/ovirt_imageio/_internal/auth.py
@@ -291,8 +291,8 @@ class Ticket:
             True if ticket can be removed.
 
         Raises:
-            errors.TicketCancelTimeout if timeout is non-zero and the ticket is
-            still used when the timeout expires.
+            errors.TransferCancelTimeout if timeout is non-zero and the ticket
+            is still used when the timeout expires.
         """
         log.debug("Cancelling transfer %s", self.transfer_id)
 

--- a/ovirt_imageio/_internal/handlers/tickets.py
+++ b/ovirt_imageio/_internal/handlers/tickets.py
@@ -97,7 +97,7 @@ class Handler:
                          req.client_addr, ticket.transfer_id)
                 try:
                     self.auth.remove(ticket_id)
-                except errors.TicketCancelTimeout as e:
+                except errors.TransferCancelTimeout as e:
                     # The ticket is still used by some connection so we cannot
                     # remove it. The caller can retry the call again when the
                     # number connections reach zero.


### PR DESCRIPTION
Change remaining instances of errors.TicketCancelTimeout to errors.TransferCancelTimeout.

Include an initial unit test that attempts to mimic two connection attempts:
-  Connection 1 initiates the transfer
-   Connection 2 issues the delete request
-   The timeout is set to 0.0001 seconds, which seemed fast enough to raise a 409 conflict

Fixes #208 