### PR TITLE
Remove stale copr build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 [![Downloads per month](https://img.shields.io/pypi/dm/ovirt-imageio)](https://pypi.org/project/ovirt-imageio/)
 [![License](https://img.shields.io/github/license/oVirt/ovirt-imageio)](https://pypi.org/project/ovirt-imageio/)
 [![CI status](https://github.com/oVirt/ovirt-imageio/actions/workflows/ci.yml/badge.svg)](https://github.com/oVirt/ovirt-imageio/actions)
-[![Copr build status](https://copr.fedorainfracloud.org/coprs/nsoffer/ovirt-imageio-preview/package/ovirt-imageio/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/nsoffer/ovirt-imageio-preview/package/ovirt-imageio/)
 
 ovirt-imageio enables uploading and downloading of disks and snapshots using HTTPS.
 


### PR DESCRIPTION
The copr repo nsoffer/ovirt-imageio-preview is not maintained for few years and does not exist now.

If we want to link to copr report for builds it should be the official oVirt copr repo.

The broken tag:
<img width="333" alt="broken-tag" src="https://github.com/user-attachments/assets/08cb3ea8-5cee-4673-8dcc-26835ad14e74" />
