### PR TITLE
containers: add epel for centos 10

### DIFF
--- a/containers/centos-10.containerfile
+++ b/containers/centos-10.containerfile
@@ -8,6 +8,7 @@ RUN echo v1 \
     && dnf install -y dnf-plugins-core \
     && dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-10 \
     && dnf install -y ovirt-release-master \
+    && dnf install -y epel-release \
     && dnf install -y \
         createrepo_c \
         e2fsprogs \


### PR DESCRIPTION
On CentOS 10, oVirt packages can depend on EPEL packages. Therefor enable epel-release in the container.