### PR TITLE
ci: Fix pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@
 
 name: CI
 on:
-- push
-- pull_request
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
 env:
   EXPORT_DIR: exported-artifacts
 jobs:
@@ -22,9 +25,9 @@ jobs:
             env: py312
           - distro: centos-10
             env: py312
-          - distro: fedora-40
-            env: py312
           - distro: fedora-41
+            env: py313
+          - distro: fedora-42
             env: py313
     container:
       image: quay.io/ovirt/ovirt-imageio-test:${{matrix.distro}}
@@ -46,8 +49,8 @@ jobs:
         distro:
         - centos-9
         - centos-10
-        - fedora-40
         - fedora-41
+        - fedora-42
     container: quay.io/ovirt/ovirt-imageio-test:${{matrix.distro}}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ centos-9, centos-10, fedora-40, fedora-41 ]
+        distro: [ centos-9, centos-10, fedora-41, fedora-42 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 prefix := ovirt-imageio-test
-targets := centos-9 centos-10 fedora-40 fedora-41
+targets := centos-9 centos-10 fedora-41 fedora-42
 
 .PHONY: $(targets) push
 

--- a/containers/fedora-42.containerfile
+++ b/containers/fedora-42.containerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Red Hat, Inc.
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:42
 
 # Runtime packages.
 RUN echo v1 \

--- a/test/qemu_nbd_test.py
+++ b/test/qemu_nbd_test.py
@@ -482,6 +482,13 @@ def test_block_signals(tmpdir):
         assert s.wait(0.2) is not None
 
 
+@pytest.mark.skipif(
+    testutil.is_centos_9_or_10,
+    reason="Blocked until patch for qemu-img regarding"
+    "using pwrite_zeroes_alignment"
+    "when writing first sector is added to CentOS."
+    "see https://gitlab.com/qemu-project/qemu/-/commit/d704a13d",
+)
 @pytest.mark.parametrize("fmt", ["raw", "qcow2"])
 def test_block_device(tmpdir, user_block, fmt):
     qemu_img.create(user_block.path, fmt, size=1024**3)

--- a/test/testutil.py
+++ b/test/testutil.py
@@ -68,3 +68,12 @@ def ipv6_enabled():
     out = subprocess.check_output(["ip", "-6", "-j", "addr"])
     addresses = json.loads(out)
     return len(addresses) > 0
+
+
+def is_centos_9_or_10():
+    try:
+        with open("/etc/os-release") as f:
+            content = f.read()
+            return ("ID=\"centos\"" in content or "ID=centos" in content)
+    except OSError:
+        return False

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ deps =
     test,bench: pytest
     test,bench: userstorage>=0.5.3
     test,bench: setuptools>=68.2.2
+    test,bench: pytest-timeout
     test: pytest-cov
-    test: pytest-timeout
 commands_pre =
     # Since Python 3.12, setuptools is not installed by default.
     pip install setuptools>=68.2.2


### PR DESCRIPTION
## Changes
* Update certain tests to only run when a high enough version of qemu-img is present.
* Drop deprecated fedora 40 and run on 42 instead.
* Utilize same header as in other oVirt project workflows.
* made python-timeout available to benchmark step to steer away from dependency issues during test run.